### PR TITLE
Fix for using order objects in queries

### DIFF
--- a/Octokit.GraphQL.Core.Generation/EnumGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/EnumGenerator.cs
@@ -80,7 +80,7 @@ namespace {rootNamespace}
         private static string GenerateEnumValue(EnumValueModel value)
         {
             return $@"        [EnumMember(Value = ""{value.Name}"")]
-        {value.Name.ToPascalCase()},";
+        {value.Name.SnakeCaseToPascalCase()},";
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/Models/RootQuery.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/RootQuery.cs
@@ -25,9 +25,29 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
             return this.CreateMethodCall(x => x.Nested(arg1, arg2), NestedQuery.Create);
         }
 
-        public IQueryable<Simple> Another(bool boolean)
+        public IQueryable<Simple> StringValue(string value)
         {
-            return this.CreateMethodCall(x => x.Another(boolean));
+            return this.CreateMethodCall(x => x.StringValue(value));
+        }
+
+        public IQueryable<Simple> BoolValue(bool boolean)
+        {
+            return this.CreateMethodCall(x => x.BoolValue(boolean));
+        }
+
+        public IQueryable<Simple> IntValue(int integer)
+        {
+            return this.CreateMethodCall(x => x.IntValue(integer));
+        }
+
+        public IQueryable<Simple> FloatValue(float flt)
+        {
+            return this.CreateMethodCall(x => x.FloatValue(flt));
+        }
+
+        public IQueryable<Simple> ObjectValue(object value)
+        {
+            return this.CreateMethodCall(x => x.ObjectValue(value));
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -279,6 +279,43 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
+        public void Object_Parameter_Hit_Cache()
+        {
+            var expected = "{objectValue(value:{value1:\"Hello World\",value2:42}){name}}";
+
+            var expression = new RootQuery()
+                .ObjectValue(new SampleObject()
+                {
+                    Value1 = "Hello World",
+                    Value2 = 42
+                })
+                .Select(x => x.Name);
+
+            var querySerializer = new QuerySerializer();
+            var queryBuilder = new QueryBuilder();
+
+            var query = queryBuilder.Build(expression);
+            var result = querySerializer.Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+
+            expected = "{objectValue(value:{value1:\"A different answer\",value2:14}){name}}";
+
+            expression = new RootQuery()
+                .ObjectValue(new SampleObject()
+                {
+                    Value1 = "A different answer",
+                    Value2 = 14
+                })
+                .Select(x => x.Name);
+
+            query = queryBuilder.Build(expression);
+            result = querySerializer.Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void Union()
         {
             var expected = @"{

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -178,12 +178,12 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
-        public void String_Parameter()
+        public void Boolean_Parameter()
         {
-            var expected = "{stringValue(value:\"hello\"){name}}";
+            var expected = "{boolValue(boolean:false){name}}";
 
             var expression = new RootQuery()
-                .StringValue("hello")
+                .BoolValue(false)
                 .Select(x => x.Name);
 
             var query = new QueryBuilder().Build(expression);
@@ -193,12 +193,12 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
-        public void Boolean_Parameter()
+        public void String_Parameter()
         {
-            var expected = "{boolValue(boolean:false){name}}";
+            var expected = "{stringValue(value:\"hello\"){name}}";
 
             var expression = new RootQuery()
-                .BoolValue(false)
+                .StringValue("hello")
                 .Select(x => x.Name);
 
             var query = new QueryBuilder().Build(expression);

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -178,12 +178,98 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
-        public void Boolean_Paramter()
+        public void String_Parameter()
         {
-            var expected = "{another(boolean:false){name}}";
+            var expected = "{stringValue(value:\"hello\"){name}}";
 
             var expression = new RootQuery()
-                .Another(false)
+                .StringValue("hello")
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Boolean_Parameter()
+        {
+            var expected = "{boolValue(boolean:false){name}}";
+
+            var expression = new RootQuery()
+                .BoolValue(false)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Integer_Parameter()
+        {
+            var expected = "{intValue(integer:123){name}}";
+
+            var expression = new RootQuery()
+                .IntValue(123)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Float_Parameter()
+        {
+            var expected = "{floatValue(flt:123.3){name}}";
+
+            var expression = new RootQuery()
+                .FloatValue(123.3f)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void Object_Null_Parameter()
+        {
+            var expected = "{objectValue{name}}";
+
+            var expression = new RootQuery()
+                .ObjectValue(null)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        public class SampleObject
+        {
+            public string Value1 { get; set; }
+
+            public int Value2 { get; set; }
+        }
+
+        [Fact]
+        public void Object_Parameter()
+        {
+            var expected = "{objectValue(value:{value1:\"Hello World\",value2:42}){name}}";
+
+            var expression = new RootQuery()
+                .ObjectValue(new SampleObject()
+                {
+                    Value1 = "Hello World",
+                    Value2 = 42
+                })
                 .Select(x => x.Name);
 
             var query = new QueryBuilder().Build(expression);

--- a/Octokit.GraphQL.Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Serializers/QuerySerializer.cs
@@ -138,6 +138,10 @@ namespace Octokit.GraphQL.Core.Serializers
             {
                 return ((bool)value) ? "true" : "false";
             }
+            else if (value.GetType().Name.EndsWith("Order"))
+            {
+                throw new NotImplementedException();
+            }
             else
             {
                 return value.ToString();

--- a/Octokit.GraphQL.Core/Syntax/SelectionSet.cs
+++ b/Octokit.GraphQL.Core/Syntax/SelectionSet.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Core.Syntax
         public static string GetIdentifier(MemberInfo member)
         {
             var attr = member?.GetCustomAttribute<GraphQLIdentifierAttribute>();
-            return attr != null ? attr.Identifier : member?.Name.ToCamelCase();
+            return attr != null ? attr.Identifier : member?.Name.LowerFirstCharacter();
         }
     }
 }

--- a/Octokit.GraphQL.Core/Utilities/StringExtensions.cs
+++ b/Octokit.GraphQL.Core/Utilities/StringExtensions.cs
@@ -1,15 +1,16 @@
 ﻿using System;
+using System.Linq;
 
 namespace Octokit.GraphQL.Core.Utilities
 {
     public static class StringExtensions
     {
-        public static string ToCamelCase(this string s)
+        public static string LowerFirstCharacter(this string s)
         {
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
         }
 
-        public static string ToPascalCase(this string str)
+        public static string SnakeCaseToPascalCase(this string str)
         {
             var tokens = str.Split(new[] { "_" }, StringSplitOptions.RemoveEmptyEntries);
 
@@ -20,6 +21,12 @@ namespace Octokit.GraphQL.Core.Utilities
             }
 
             return string.Join("", tokens);
+        }
+
+        public static string PascalCaseToSnakeCase(this string s)
+        {
+            return string.Concat(s.ToCharArray()
+                .Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToUpper();
         }
     }
 }


### PR DESCRIPTION
Depends on:
- [x] #15 

In order to fix the integration tests:
1. `RepositoryTests.Should_QueryRepositoryOwner_Repositories_OrderBy_Name_Ascending`
2. `RepositoryTests.Should_QueryRepositoryOwner_Repositories_OrderBy_CreatedAt_Descending`

Which currently fail with the following exception:
```
System.AggregateException : One or more errors occurred.
---- Octokit.GraphQL.Core.GraphQLQueryException : Parse error on "." (error) at [1, 70]
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Octokit.GraphQL.IntegrationTests.RepositoryTests.Should_QueryRepositoryOwner_Repositories_OrderBy_Name_Ascending() in C:\Users\Spade\Projects\GitHub\Octokit.GraphQL\Octokit.GraphQL.IntegrationTests\RepositoryTests.cs:line 36
----- Inner Stack Trace -----
   at Octokit.GraphQL.Core.Deserializers.ResponseDeserializer.Deserialize[TResult](GraphQLQuery`1 query, JObject data)
   at Octokit.GraphQL.Core.Deserializers.ResponseDeserializer.Deserialize[TResult](GraphQLQuery`1 query, String data)
   at Octokit.GraphQL.Core.Connection.<Run>d__6`1.MoveNext()
```

From a query with the code:
```
var query = new Query().RepositoryOwner("octokit").Repositories(first: 30, orderBy: new RepositoryOrder
{
    Direction = OrderDirection.Asc,
    Field = RepositoryOrderField.Name
}).Nodes.Select(repository => repository.Name);
```

The query generated is malformed:
```
{
  repositoryOwner(login: "octokit") {
    repositories(first: 30, orderBy: Octokit.GraphQL.RepositoryOrder) {
      nodes {
        name
      }
    }
  }
}
```

The correct value of `orderBy` should be `{field: NAME, direction: ASC}`