### PR TITLE
Fix to correctly generate methods that have defaulted enum parameters

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -632,6 +632,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [InlineData(TypeKind.Scalar, "Int", "int", "5", "5")]
         [InlineData(TypeKind.Scalar, "Boolean", "bool", "true", "true")]
         [InlineData(TypeKind.Scalar, "String", "string", "foo", "\"foo\"")]
+        [InlineData(TypeKind.Enum, "EnumType", "EnumType", "FOO", "EnumType.Foo")]
         public void NonNull_Arg_With_DefaultValue_Has_Default(TypeKind argType, string type, string csharpType, string defaultValue, string csharpDefaultValue)
         {
             var expected = FormatMemberTemplate($"public IOther Foo({csharpType} bar = {csharpDefaultValue}) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");

--- a/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
+++ b/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Octokit.GraphQL.Core.Generation.Models;
 using Octokit.GraphQL.Core.Introspection;
+using Octokit.GraphQL.Core.Utilities;
 
 namespace Octokit.GraphQL.Core.Generation.Utilities
 {
@@ -21,7 +22,7 @@ namespace Octokit.GraphQL.Core.Generation.Utilities
             }
             else if (type.Kind == TypeKind.Enum)
             {
-                return $"{type.Name}.{value}";
+                return $"{type.Name}.{value.SnakeCaseToPascalCase()}";
             }
             else if (type.Kind == TypeKind.NonNull)
             {


### PR DESCRIPTION
In `Team.Members(...)`
We are currently generating `TeamMembershipType? membership = TeamMembershipType.ALL` we need to generate `TeamMembershipType? membership = TeamMembershipType.All`

#38 depends on this