### PR TITLE
Fix to support multiline documentation items

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -853,6 +853,51 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         }
 
         [Fact]
+        public void Generates_Multi_Line_Doc_Comments_For_Method()
+        {
+            var expected = FormatMemberTemplate(@"/// <summary>
+        /// Testing if doc comments are generated.
+        /// Testing if doc comments are generated.
+        /// Testing if doc comments are generated.
+        /// </summary>
+        /// <param name=""arg1"">The first argument.</param>
+        public Other Foo(int? arg1 = null, int? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Description = "Testing if doc comments are generated.\r\nTesting if doc comments are generated.\r\nTesting if doc comments are generated.\r\n",
+                        Type = TypeModel.Object("Other"),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "arg1",
+                                Description = "The first argument.",
+                                Type = TypeModel.Int(),
+                            },
+                            new InputValueModel
+                            {
+                                Name = "arg2",
+                                Type = TypeModel.Int(),
+                            },
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void Generates_Root_Query()
         {
             var expected = @"namespace Test

--- a/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
@@ -146,10 +146,16 @@ namespace Octokit.GraphQL.Core.Generation
         {
             if (generate && !string.IsNullOrWhiteSpace(field.Description))
             {
-                var builder = new StringBuilder($@"        /// <summary>
-        /// {field.Description}
-        /// </summary>
-");
+                var builder = new StringBuilder($@"        /// <summary>");
+                builder.AppendLine();
+
+                foreach (var line in field.Description.Split('\r', '\n')
+                    .Where(l => !(string.IsNullOrEmpty(l) && string.IsNullOrWhiteSpace(l))))
+                {
+                    builder.AppendLine($"        /// {line}");
+                }
+
+                builder.AppendLine(@"        /// </summary>");
 
                 if (field.Args != null)
                 {


### PR DESCRIPTION
I remember @iAmWillShepherd saying he pushed this to master accidentally.
Since this fix is part of a series of fixes to generate the model against the current schema, I pulled it out of master and into it's own pull request.

#38 depends on this