### PR TITLE
QueryEntityExtensions must be in Octokit.GraphQL.

### DIFF
--- a/Octokit.GraphQL.Core/QueryEntityExtensions.cs
+++ b/Octokit.GraphQL.Core/QueryEntityExtensions.cs
@@ -2,8 +2,9 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Octokit.GraphQL.Core;
 
-namespace Octokit.GraphQL.Core
+namespace Octokit.GraphQL
 {
     public static class QueryEntityExtensions
     {


### PR DESCRIPTION
Otherwise you need a `using Octokit.GraphQL.Core` to write queries.