### PR TITLE
Handle InputObject parameter with null field.

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/Models/InputObject.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/InputObject.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Octokit.GraphQL.Core.UnitTests.Models
+{
+    class InputObject
+    {
+        public string StringValue { get; set; }
+    }
+}

--- a/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
@@ -55,5 +55,10 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
         {
             return this.CreateMethodCall(x => x.EnumerableValue(value));
         }
+
+        public IQueryable<Simple> InputObject(InputObject input)
+        {
+            return this.CreateMethodCall(x => x.InputObject(input));
+        }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -375,6 +375,46 @@ namespace Octokit.GraphQL.Core.UnitTests
             Assert.Equal(expected, result);
         }
 
+        [Fact]
+        public void InputObject_Parameter()
+        {
+            var expected = "query{inputObject(input:{stringValue:\"foo\"}){name}}";
+
+            var input = new InputObject
+            {
+                StringValue = "foo",
+            };
+
+            var expression = new TestQuery()
+                .InputObject(input)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void InputObject_Parameter_With_Null_Field()
+        {
+            var expected = "query{inputObject(input:{stringValue:null}){name}}";
+
+            var input = new InputObject
+            {
+                StringValue = null,
+            };
+
+            var expression = new TestQuery()
+                .InputObject(input)
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
         public class SampleObject
         {
             public string Value1 { get; set; }

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -148,7 +148,11 @@ namespace Octokit.GraphQL.Core.Serializers
 
         private void SerializeValue(StringBuilder builder, object value)
         {
-            if (value is string)
+            if (value == null)
+            {
+                builder.Append("null");
+            }
+            else if (value is string)
             {
                 builder.Append('"' + ((string)value) + '"');
             }


### PR DESCRIPTION
This was previously throwing a NRE, as tested by `InputObject_Parameter_With_Null_Field`.