### PR TITLE
Making it easier to generate model files

### DIFF
--- a/Tools/Generate/Program.cs
+++ b/Tools/Generate/Program.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Octokit.GraphQL;
 using Octokit.GraphQL.Core.Generation;
 using System.IO;
+using System.Linq;
 
 namespace Generate
 {
@@ -31,6 +32,14 @@ namespace Generate
             if (!Directory.Exists(modelPath))
             {
                 Directory.CreateDirectory(modelPath);
+            }
+
+            var csFiles = Directory.EnumerateFiles(path, "*.cs")
+                .Union(Directory.EnumerateFiles(modelPath, "*.cs"));
+
+            foreach (var csFile in csFiles)
+            {
+                File.Delete(csFile);
             }
 
             var header = new ProductHeaderValue("Octokit.GraphQL", "0.1");


### PR DESCRIPTION
Removing all files at the target path of the generate executable allows a developer to point the output directly at the Octokit.GraphQL project.
Which allows them to iterate on the model quicker.