### PR TITLE
Support casts to enums in `Select` statements

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/Models/Simple.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/Simple.cs
@@ -13,6 +13,7 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
         public string Name { get; set; }
         public string Description { get; set; }
         public int Number { get; set; }
+        public int? NullableNumber { get; set; }
 
         internal static Simple Create(Expression expression)
         {

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -103,6 +103,24 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
+        public void SimpleQuery_Cast_NUllable_Member_To_Enum()
+        {
+            var expected = "query{simple(arg1:\"foo\"){number}}";
+
+            var expression = new TestQuery()
+                .Simple("foo")
+                .Select(x => new
+                {
+                    Float = (DayOfWeek)x.NullableNumber.Value
+                });
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void Data_Select_Single_Member()
         {
             var expected = "query{queryItems{id}}";

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -85,6 +85,24 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
+        public void SimpleQuery_Cast_Member_To_Enum()
+        {
+            var expected = "query{simple(arg1:\"foo\"){number}}";
+
+            var expression = new TestQuery()
+                .Simple("foo")
+                .Select(x => new
+                {
+                    Float = (DayOfWeek)x.Number
+                });
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
         public void Data_Select_Single_Member()
         {
             var expected = "query{queryItems{id}}";

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -103,9 +103,9 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
-        public void SimpleQuery_Cast_NUllable_Member_To_Enum()
+        public void SimpleQuery_Cast_Nullable_Member_To_Enum()
         {
-            var expected = "query{simple(arg1:\"foo\"){number}}";
+            var expected = "query{simple(arg1:\"foo\"){nullableNumber}}";
 
             var expression = new TestQuery()
                 .Simple("foo")

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -166,6 +166,12 @@ namespace Octokit.GraphQL.Core.Builders
 
         protected override Expression VisitUnary(UnaryExpression node)
         {
+            if (node.NodeType == ExpressionType.Convert)
+            {
+                var rewritten = Visit(node.Operand);
+                return rewritten.AddCast(node.Type);
+            }
+
             return node.Update(Visit(node.Operand));
         }
 

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -169,7 +169,11 @@ namespace Octokit.GraphQL.Core.Builders
             if (node.NodeType == ExpressionType.Convert)
             {
                 var rewritten = Visit(node.Operand);
-                return rewritten.AddCast(node.Type);
+
+                if (rewritten.Type == typeof(JToken))
+                {
+                    return rewritten.AddCast(node.Type);
+                }
             }
 
             return node.Update(Visit(node.Operand));

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -172,7 +172,9 @@ namespace Octokit.GraphQL.Core.Builders
 
                 if (rewritten.Type == typeof(JToken))
                 {
-                    return rewritten.AddCast(node.Type);
+                    return Expression.Convert(
+                        rewritten.AddCast(node.Operand.Type),
+                        node.Type);
                 }
             }
 

--- a/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
+++ b/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Octokit.GraphQL</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
+++ b/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
@@ -247,5 +247,38 @@ namespace Octokit.GraphQL.UnitTests
 
             Assert.Equal(PullRequestReviewState.ChangesRequested, result[0].State);
         }
+
+        [Fact]
+        public void PullRequest_Review_State_ChangesRequested_Cast_To_Int()
+        {
+            var expression = new Query()
+                .Repository("grokys", "VisualStudio")
+                .PullRequest(1)
+                .Reviews(first: 30)
+                .Select(x => x.Nodes)
+                .Select(x => new
+                {
+                    State = (int)x.State
+                });
+
+            string data = @"{
+  ""data"": {
+    ""repository"": {
+      ""pullRequest"": {
+        ""reviews"": {
+          ""nodes"": [{
+            ""state"": ""CHANGES_REQUESTED""
+          }]
+        }
+      }
+    }
+  }
+}";
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new ResponseDeserializer().Deserialize(query, data).ToList();
+
+            Assert.Equal(3, result[0].State);
+        }
     }
 }

--- a/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
+++ b/Octokit.GraphQL.UnitTests/ResponseDeserializerTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Octokit.GraphQL.Core;
 using Octokit.GraphQL.Core.Builders;
 using Octokit.GraphQL.Core.Deserializers;
+using Octokit.GraphQL.Model;
 using Xunit;
 
 namespace Octokit.GraphQL.UnitTests
@@ -212,6 +213,39 @@ namespace Octokit.GraphQL.UnitTests
             }
 
             Assert.True(thrown);
+        }
+
+        [Fact]
+        public void PullRequest_Review_State_ChangesRequested()
+        {
+            var expression = new Query()
+                .Repository("grokys", "VisualStudio")
+                .PullRequest(1)
+                .Reviews(first : 30)
+                .Select(x => x.Nodes)
+                .Select(x => new
+                {
+                    x.State
+                });
+
+            string data = @"{
+  ""data"": {
+    ""repository"": {
+      ""pullRequest"": {
+        ""reviews"": {
+          ""nodes"": [{
+            ""state"": ""CHANGES_REQUESTED""
+          }]
+        }
+      }
+    }
+  }
+}";
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new ResponseDeserializer().Deserialize(query, data).ToList();
+
+            Assert.Equal(PullRequestReviewState.ChangesRequested, result[0].State);
         }
     }
 }


### PR DESCRIPTION
- Fix explicit casts in `Select` statements.
- Updated Newtonsoft.Json to fix JamesNK/Newtonsoft.Json#616

Fixes #58.