### PR TITLE
Initial Implementation of Variables

### DIFF
--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -701,7 +701,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_Object_Field_With_Args()
         {
-            var expected = FormatMemberTemplate("public Other Foo(int bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
+            var expected = FormatMemberTemplate("public Other Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
 
             var model = new TypeModel
             {
@@ -733,7 +733,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_NonNull_Object_Field_With_Args()
         {
-            var expected = FormatMemberTemplate("public Other Foo(int bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
+            var expected = FormatMemberTemplate("public Other Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
 
             var model = new TypeModel
             {
@@ -765,7 +765,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_Interface_Field_With_Args()
         {
-            var expected = FormatMemberTemplate("public IOther Foo(int bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
+            var expected = FormatMemberTemplate("public IOther Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
             {
@@ -797,7 +797,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_List_Field_With_Int_Arg()
         {
-            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(int? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(Arg<int>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -829,7 +829,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_List_Field_With_Object_List_Arg()
         {
-            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(IEnumerable<Another> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -861,7 +861,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_List_Field_With_NonNull_Enum_List_Arg()
         {
-            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(IEnumerable<Another> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -893,7 +893,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_List_Field_With_Nullable_Enum_List_Arg()
         {
-            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(IEnumerable<Another?> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+            var expected = FormatMemberTemplate("public IQueryableList<Other> Foo(Arg<IEnumerable<Another?>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -923,9 +923,73 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         }
 
         [Fact]
+        public void Generates_Method_For_String_Field()
+        {
+            var expected = FormatMemberTemplate("public int? Foo(Arg<string>? bar = null) => null;");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.Int(),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "bar",
+                                Type = TypeModel.String(),
+                            }
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            Assert.Equal(new GeneratedFile(@"Model\Entity.cs", expected), result);
+        }
+
+        [Fact]
+        public void Generates_Method_For_NonNull_String_Field()
+        {
+            var expected = FormatMemberTemplate("public int? Foo(Arg<string> bar) => null;");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.Int(),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "bar",
+                                Type = TypeModel.NonNull(TypeModel.String()),
+                            }
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            Assert.Equal(new GeneratedFile(@"Model\Entity.cs", expected), result);
+        }
+
+        [Fact]
         public void Generates_Method_For_Scalar_Field()
         {
-            var expected = FormatMemberTemplate("public int? Foo(int? bar = null) => null;");
+            var expected = FormatMemberTemplate("public int? Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -957,7 +1021,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_Deprecated_WithoutReason_Scalar_Field()
         {
-            var expected = FormatMemberTemplate($@"[Obsolete(@""Old and unused"")]{Environment.NewLine}        public int? Foo(int? bar = null) => null;");
+            var expected = FormatMemberTemplate($@"[Obsolete(@""Old and unused"")]{Environment.NewLine}        public int? Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -991,7 +1055,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_Deprecated_Scalar_Field()
         {
-            var expected = FormatMemberTemplate($@"[Obsolete]{Environment.NewLine}        public int? Foo(int? bar = null) => null;");
+            var expected = FormatMemberTemplate($@"[Obsolete]{Environment.NewLine}        public int? Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -1024,7 +1088,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_NonNull_Scalar_Field()
         {
-            var expected = FormatMemberTemplate("public int Foo(int? bar = null) => null;");
+            var expected = FormatMemberTemplate("public int Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -1056,7 +1120,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [Fact]
         public void Generates_Method_For_Union_Field()
         {
-            var expected = FormatMemberTemplate("public Bar Foo(int? bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Bar.Create);");
+            var expected = FormatMemberTemplate("public Bar Foo(Arg<int>? bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Bar.Create);");
 
             var model = new TypeModel
             {
@@ -1092,7 +1156,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         [InlineData(TypeKind.InputObject, "InputObj", "InputObj")]
         public void NonNull_Arg_With_Null_DefaultValue_Has_No_Default(TypeKind argType, string type, string csharpType)
         {
-            var expected = FormatMemberTemplate($"public IOther Foo({csharpType} bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
+            var expected = FormatMemberTemplate($"public IOther Foo(Arg<{csharpType}> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
             {
@@ -1126,54 +1190,13 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         }
 
         [Theory]
-        [InlineData(TypeKind.Scalar, "Int", "int", "5", "5")]
-        [InlineData(TypeKind.Scalar, "Boolean", "bool", "true", "true")]
-        [InlineData(TypeKind.Scalar, "String", "string", "foo", "\"foo\"")]
-        [InlineData(TypeKind.Enum, "EnumType", "EnumType", "FOO", "EnumType.Foo")]
-        public void NonNull_Arg_With_DefaultValue_Has_Default(TypeKind argType, string type, string csharpType, string defaultValue, string csharpDefaultValue)
-        {
-            var expected = FormatMemberTemplate($"public IOther Foo({csharpType} bar = {csharpDefaultValue}) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
-
-            var model = new TypeModel
-            {
-                Name = "Entity",
-                Kind = TypeKind.Object,
-                Fields = new[]
-                {
-                    new FieldModel
-                    {
-                        Name = "foo",
-                        Type = TypeModel.Interface("Other"),
-                        Args = new[]
-                        {
-                            new InputValueModel
-                            {
-                                Name = "bar",
-                                Type = TypeModel.NonNull(new TypeModel
-                                {
-                                    Kind = argType,
-                                    Name = type,
-                                }),
-                                DefaultValue = defaultValue,
-                            }
-                        }
-                    },
-                }
-            };
-
-            var result = CodeGenerator.Generate(model, "Test", null);
-
-            Assert.Equal(new GeneratedFile(@"Model\Entity.cs", expected), result);
-        }
-
-        [Theory]
-        [InlineData(TypeKind.Scalar, "Int", "int?")]
-        [InlineData(TypeKind.Scalar, "Boolean", "bool?")]
+        [InlineData(TypeKind.Scalar, "Int", "int")]
+        [InlineData(TypeKind.Scalar, "Boolean", "bool")]
         [InlineData(TypeKind.Scalar, "String", "string")]
         [InlineData(TypeKind.InputObject, "InputObj", "InputObj")]
         public void Nullable_Arg_With_No_DefaultValue_Has_Default(TypeKind argType, string type, string csharpType)
         {
-            var expected = FormatMemberTemplate($"public IOther Foo({csharpType} bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
+            var expected = FormatMemberTemplate($"public IOther Foo(Arg<{csharpType}>? bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
             {
@@ -1210,7 +1233,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         public void Args_With_Default_Values_Come_After_Args_With_No_Default_Values()
         {
             var expected = FormatMemberTemplate(
-                "public IOther Foo(int req1, int req2, int? opt1 = null, int opt2 = 5) => " + 
+                "public IOther Foo(Arg<int> req1, Arg<int> req2, Arg<int>? opt1 = null, Arg<int>? opt2 = null) => " + 
                 "this.CreateMethodCall(x => x.Foo(req1, req2, opt1, opt2), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
@@ -1228,7 +1251,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
                             new InputValueModel { Name = "req1", Type = TypeModel.NonNull(TypeModel.Int()) },
                             new InputValueModel { Name = "opt1", Type = TypeModel.Int() },
                             new InputValueModel { Name = "req2", Type = TypeModel.NonNull(TypeModel.Int()) },
-                            new InputValueModel { Name = "opt2", Type = TypeModel.NonNull(TypeModel.Int()), DefaultValue = "5" },
+                            new InputValueModel { Name = "opt2", Type = TypeModel.Int(), DefaultValue = "5" },
                         }
                     },
                 }
@@ -1315,7 +1338,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         /// </summary>
         /// <param name=""arg1"">The first argument.</param>
         /// <param name=""arg2"">The second argument. With a windows newline. Ending with a space.</param>
-        public Other Foo(int? arg1 = null, int? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
+        public Other Foo(Arg<int>? arg1 = null, Arg<int>? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
 
             var model = new TypeModel
             {
@@ -1362,7 +1385,7 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         /// </summary>
         /// <param name=""arg1"">The first argument.</param>
         /// <param name=""arg2"">The second argument. With a linux newline. Ending with a newline.</param>
-        public Other Foo(int? arg1 = null, int? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
+        public Other Foo(Arg<int>? arg1 = null, Arg<int>? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
 
             var model = new TypeModel
             {

--- a/Octokit.GraphQL.Core.Generation.UnitTests/InterfaceGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/InterfaceGenerationTests.cs
@@ -204,8 +204,8 @@ namespace Test.Internal
         public void Generates_Method_For_Object_Field_With_Int_Arg()
         {
             var expected = FormatMemberTemplate(
-                "Other Foo(int bar);",
-                "public Other Foo(int bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
+                "Other Foo(Arg<int> bar);",
+                "public Other Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
 
             var model = new TypeModel
             {
@@ -238,8 +238,8 @@ namespace Test.Internal
         public void Generates_Method_For_NonNull_Object_Field_With_Int_Arg()
         {
             var expected = FormatMemberTemplate(
-                "Other Foo(int bar);",
-                "public Other Foo(int bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
+                "Other Foo(Arg<int> bar);",
+                "public Other Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
 
             var model = new TypeModel
             {
@@ -272,8 +272,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_Nullable_Int_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(int? bar = null);",
-                "public IQueryableList<Other> Foo(int? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<int>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<int>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -306,8 +306,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_Nullable_Int_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<int?> bar = null);",
-                "public IQueryableList<Other> Foo(IEnumerable<int?> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<int?>>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<int?>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -340,8 +340,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_NotNull_Int_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<int> bar = null);",
-                "public IQueryableList<Other> Foo(IEnumerable<int> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<int>>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<int>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -374,8 +374,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_Object_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<Another> bar = null);",
-                "public IQueryableList<Other> Foo(IEnumerable<Another> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -408,8 +408,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_NonNull_Object_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<Another> bar);",
-                "public IQueryableList<Other> Foo(IEnumerable<Another> bar) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<Another>> bar);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<Another>> bar) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -442,8 +442,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_Nullable_Enum_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<Another?> bar = null);",
-                "public IQueryableList<Other> Foo(IEnumerable<Another?> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<Another?>>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<Another?>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -476,8 +476,8 @@ namespace Test.Internal
         public void Generates_Method_For_List_Field_With_NonNull_Enum_List_Arg()
         {
             var expected = FormatMemberTemplate(
-                "IQueryableList<Other> Foo(IEnumerable<Another> bar = null);",
-                "public IQueryableList<Other> Foo(IEnumerable<Another> bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
+                "IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null);",
+                "public IQueryableList<Other> Foo(Arg<IEnumerable<Another>>? bar = null) => this.CreateMethodCall(x => x.Foo(bar));");
 
             var model = new TypeModel
             {
@@ -510,8 +510,8 @@ namespace Test.Internal
         public void Generates_Method_For_Scalar()
         {
             var expected = FormatMemberTemplate(
-                "int? Foo(int? bar = null);",
-                "public int? Foo(int? bar = null) => null;");
+                "int? Foo(Arg<int>? bar = null);",
+                "public int? Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -544,8 +544,8 @@ namespace Test.Internal
         public void Generates_Method_For_NonNull_Scalar()
         {
             var expected = FormatMemberTemplate(
-                "int Foo(int? bar = null);",
-                "public int Foo(int? bar = null) => null;");
+                "int Foo(Arg<int>? bar = null);",
+                "public int Foo(Arg<int>? bar = null) => null;");
 
             var model = new TypeModel
             {
@@ -582,8 +582,8 @@ namespace Test.Internal
         public void NonNull_Arg_With_Null_DefaultValue_Has_No_Default(TypeKind argType, string type, string csharpType)
         {
             var expected = FormatMemberTemplate(
-                $"IOther Foo({csharpType} bar);",
-                $"public IOther Foo({csharpType} bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
+                $"IOther Foo(Arg<{csharpType}> bar);",
+                $"public IOther Foo(Arg<{csharpType}> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
             {
@@ -617,57 +617,15 @@ namespace Test.Internal
         }
 
         [Theory]
-        [InlineData(TypeKind.Scalar, "Int", "int", "5", "5")]
-        [InlineData(TypeKind.Scalar, "Boolean", "bool", "true", "true")]
-        [InlineData(TypeKind.Scalar, "String", "string", "foo", "\"foo\"")]
-        public void NonNull_Arg_With_DefaultValue_Has_Default(TypeKind argType, string type, string csharpType, string defaultValue, string csharpDefaultValue)
-        {
-            var expected = FormatMemberTemplate(
-                $"IOther Foo({csharpType} bar = {csharpDefaultValue});",
-                $"public IOther Foo({csharpType} bar = {csharpDefaultValue}) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
-
-            var model = new TypeModel
-            {
-                Name = "Entity",
-                Kind = TypeKind.Interface,
-                Fields = new[]
-                {
-                    new FieldModel
-                    {
-                        Name = "foo",
-                        Type = TypeModel.Interface("Other"),
-                        Args = new[]
-                        {
-                            new InputValueModel
-                            {
-                                Name = "bar",
-                                Type = TypeModel.NonNull(new TypeModel
-                                {
-                                    Kind = argType,
-                                    Name = type,
-                                }),
-                                DefaultValue = defaultValue,
-                            }
-                        }
-                    },
-                }
-            };
-
-            var result = CodeGenerator.Generate(model, "Test", null);
-
-            Assert.Equal(new GeneratedFile(@"Model\Entity.cs", expected), result);
-        }
-
-        [Theory]
-        [InlineData(TypeKind.Scalar, "Int", "int?")]
-        [InlineData(TypeKind.Scalar, "Boolean", "bool?")]
+        [InlineData(TypeKind.Scalar, "Int", "int")]
+        [InlineData(TypeKind.Scalar, "Boolean", "bool")]
         [InlineData(TypeKind.Scalar, "String", "string")]
         [InlineData(TypeKind.InputObject, "InputObj", "InputObj")]
         public void Nullable_Arg_With_No_DefaultValue_Has_Default(TypeKind argType, string type, string csharpType)
         {
             var expected = FormatMemberTemplate(
-                $"IOther Foo({csharpType} bar = null);",
-                $"public IOther Foo({csharpType} bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
+                $"IOther Foo(Arg<{csharpType}>? bar = null);",
+                $"public IOther Foo(Arg<{csharpType}>? bar = null) => this.CreateMethodCall(x => x.Foo(bar), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
             {
@@ -704,8 +662,8 @@ namespace Test.Internal
         public void Args_With_Default_Values_Come_After_Args_With_No_Default_Values()
         {
             var expected = FormatMemberTemplate(
-                "IOther Foo(int req1, int req2, int? opt1 = null, int opt2 = 5);",
-                "public IOther Foo(int req1, int req2, int? opt1 = null, int opt2 = 5) => " +
+                "IOther Foo(Arg<int> req1, Arg<int> req2, Arg<int>? opt1 = null, Arg<int>? opt2 = null);",
+                "public IOther Foo(Arg<int> req1, Arg<int> req2, Arg<int>? opt1 = null, Arg<int>? opt2 = null) => " +
                 "this.CreateMethodCall(x => x.Foo(req1, req2, opt1, opt2), Test.Internal.StubIOther.Create);");
 
             var model = new TypeModel
@@ -723,7 +681,7 @@ namespace Test.Internal
                             new InputValueModel { Name = "req1", Type = TypeModel.NonNull(TypeModel.Int()) },
                             new InputValueModel { Name = "opt1", Type = TypeModel.Int() },
                             new InputValueModel { Name = "req2", Type = TypeModel.NonNull(TypeModel.Int()) },
-                            new InputValueModel { Name = "opt2", Type = TypeModel.NonNull(TypeModel.Int()), DefaultValue = "5" },
+                            new InputValueModel { Name = "opt2", Type = TypeModel.Int(), DefaultValue = "5" },
                         }
                     },
                 }
@@ -812,8 +770,8 @@ namespace Test.Internal
         /// Testing if doc comments are generated.
         /// </summary>
         /// <param name=""arg1"">The first argument.</param>
-        Other Foo(int? arg1 = null, int? arg2 = null);",
-                "public Other Foo(int? arg1 = null, int? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
+        Other Foo(Arg<int>? arg1 = null, Arg<int>? arg2 = null);",
+                "public Other Foo(Arg<int>? arg1 = null, Arg<int>? arg2 = null) => this.CreateMethodCall(x => x.Foo(arg1, arg2), Test.Other.Create);");
 
             var model = new TypeModel
             {

--- a/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/EntityGenerator.cs
@@ -268,19 +268,19 @@ namespace Octokit.GraphQL.Core.Generation
                 }
 
                 var argName = TypeUtilities.GetArgName(arg);
-                argBuilder.Append(TypeUtilities.GetCSharpArgType(arg.Type));
-                argBuilder.Append(' ');
-                argBuilder.Append(argName);
+                argBuilder
+                    .Append(TypeUtilities.GetWrappedArgType(arg.Type))
+                    .Append(' ')
+                    .Append(argName);
                 paramBuilder.Append(argName);
 
-                if (arg.DefaultValue != null)
-                {
-                    argBuilder.Append(" = ");
-                    argBuilder.Append(TypeUtilities.GetCSharpLiteral(arg.DefaultValue, arg.Type));
-                }
-                else if (arg.Type.Kind != TypeKind.NonNull)
+                if (arg.Type.Kind != TypeKind.NonNull)
                 {
                     argBuilder.Append(" = null");
+                }
+                else if (arg.DefaultValue != null)
+                {
+                    throw new Exception("Encountered default value for non-null type.");
                 }
 
                 first = false;

--- a/Octokit.GraphQL.Core.Generation/InterfaceGenerator.cs
+++ b/Octokit.GraphQL.Core.Generation/InterfaceGenerator.cs
@@ -199,19 +199,18 @@ namespace Octokit.GraphQL.Core.Generation
                 }
 
                 var argName = TypeUtilities.GetArgName(arg);
-                argBuilder.Append(TypeUtilities.GetCSharpArgType(arg.Type));
+                argBuilder.Append(TypeUtilities.GetWrappedArgType(arg.Type));
                 argBuilder.Append(' ');
                 argBuilder.Append(argName);
                 paramBuilder.Append(argName);
 
-                if (arg.DefaultValue != null)
-                {
-                    argBuilder.Append(" = ");
-                    argBuilder.Append(TypeUtilities.GetCSharpLiteral(arg.DefaultValue, arg.Type));
-                }
-                else if (arg.Type.Kind != TypeKind.NonNull)
+                if (arg.Type.Kind != TypeKind.NonNull)
                 {
                     argBuilder.Append(" = null");
+                }
+                else if (arg.DefaultValue != null)
+                {
+                    throw new Exception("Encountered default value for non-null type.");
                 }
 
                 first = false;

--- a/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
+++ b/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
@@ -42,6 +42,13 @@ namespace Octokit.GraphQL.Core.Generation.Utilities
             return GetCSharpType(ReduceType(type), type.Kind != TypeKind.NonNull, false);
         }
 
+        public static string GetWrappedArgType(TypeModel type)
+        {
+            var csharpType = GetCSharpType(ReduceType(type), false, false);
+            var nullable = type.Kind != TypeKind.NonNull ? "?" : string.Empty;
+            return "Arg<" + csharpType + '>' + nullable;
+        }
+
         public static string GetClassName(TypeModel type)
         {
             return PascalCase(type.Name);

--- a/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Linq.Expressions;
 using Newtonsoft.Json.Linq;
 using Octokit.GraphQL.Core.Builders;
@@ -21,7 +20,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             Expression<Func<JObject, string>> expected = data =>
                 Rewritten.Value.Select(data["data"]["simple"], x => x["name"]).ToObject<string>();
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -39,7 +38,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Description = x["description"].ToObject<string>(),
                 });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -53,7 +52,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             Expression<Func<JObject, IEnumerable<string>>> expected = data =>
                 Rewritten.List.Select(data["data"]["queryItems"], x => x["id"].ToObject<string>());
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -72,7 +71,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Description = x["description"].ToObject<string>(),
                 });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -96,7 +95,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                         Items = Rewritten.List.ToList<string>(Rewritten.List.Select(x["nestedItems"], i => i["name"]))
                     });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -129,7 +128,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                                 }))
                     });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -162,7 +161,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                                 }))
                     });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -187,7 +186,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                         Items = Rewritten.List.ToList<string>(Rewritten.List.Select(x["nestedItems"], i => i["name"]))
                     });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -213,7 +212,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                         Description = x["description"].ToObject<string>(),
                     });
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
 
@@ -230,7 +229,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Rewritten.Interface.Cast(data["data"]["node"], "Simple"),
                     x => x["name"]).ToObject<string>();
 
-            var query = new QueryBuilder().Build(expression);
+            var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
     }

--- a/Octokit.GraphQL.Core.UnitTests/IntrospectionTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/IntrospectionTests.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using Octokit.GraphQL.Core.Builders;
+﻿using System.Collections.Generic;
 using Octokit.GraphQL.Core.Deserializers;
 using Octokit.GraphQL.Core.Introspection;
-using Octokit.GraphQL.Core.Serializers;
 using Xunit;
 
 namespace Octokit.GraphQL.Core.UnitTests
@@ -19,10 +16,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Schema.QueryType
                 .Select(x => x.Kind);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -84,10 +80,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     }).ToList()
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var queryResult = new QuerySerializer(2).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expectedQuery, queryResult);
+            Assert.Equal(expectedQuery, query.ToString());
 
             var responseResult = new ResponseDeserializer().Deserialize(query, data);
 
@@ -134,10 +129,9 @@ namespace Octokit.GraphQL.Core.UnitTests
     }
   }
 }";
-            var query = new QueryBuilder().Build(expression);
-            var queryResult = new QuerySerializer(2).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expectedQuery, queryResult);
+            Assert.Equal(expectedQuery, query.ToString());
         }
 
         private class SchemaModel

--- a/Octokit.GraphQL.Core.UnitTests/Models/NestedQuery.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/NestedQuery.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
         {
         }
 
-        public Simple Simple(string arg1)
+        public Simple Simple(Arg<string> arg1)
         {
             return this.CreateMethodCall(x => x.Simple(arg1), Models.Simple.Create);
         }

--- a/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
@@ -15,47 +15,47 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
 
         public Union Union => this.CreateProperty(x => Union, Union.Create);
 
-        public Simple Simple(string arg1, int? arg2 = null)
+        public Simple Simple(Arg<string> arg1, Arg<int>? arg2 = null)
         {
             return this.CreateMethodCall(x => x.Simple(arg1, arg2), Models.Simple.Create);
         }
 
-        public NestedQuery Nested(string arg1, int? arg2 = null)
+        public NestedQuery Nested(Arg<string> arg1, Arg<int>? arg2 = null)
         {
             return this.CreateMethodCall(x => x.Nested(arg1, arg2), NestedQuery.Create);
         }
 
-        public Simple StringValue(string value)
+        public Simple StringValue(Arg<string> value)
         {
             return this.CreateMethodCall(x => x.StringValue(value), Models.Simple.Create);
         }
 
-        public Simple BoolValue(bool boolean)
+        public Simple BoolValue(Arg<bool> boolean)
         {
             return this.CreateMethodCall(x => x.BoolValue(boolean), Models.Simple.Create);
         }
 
-        public Simple IntValue(int integer)
+        public Simple IntValue(Arg<int> integer)
         {
             return this.CreateMethodCall(x => x.IntValue(integer), Models.Simple.Create);
         }
 
-        public Simple FloatValue(float flt)
+        public Simple FloatValue(Arg<float> flt)
         {
             return this.CreateMethodCall(x => x.FloatValue(flt), Models.Simple.Create);
         }
 
-        public Simple ObjectValue(object value)
+        public Simple ObjectValue(Arg<object> value)
         {
             return this.CreateMethodCall(x => x.ObjectValue(value), Models.Simple.Create);
         }
 
-        public Simple EnumerableValue(IEnumerable<object> value)
+        public Simple EnumerableValue(Arg<IEnumerable<object>> value)
         {
             return this.CreateMethodCall(x => x.EnumerableValue(value), Models.Simple.Create);
         }
 
-        public Simple InputObject(InputObject input)
+        public Simple InputObject(Arg<InputObject> input)
         {
             return this.CreateMethodCall(x => x.InputObject(input), Models.Simple.Create);
         }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -546,5 +546,35 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void IntValue_Variable()
+        {
+            var expected = "query($var1:Int){intValue(integer:$var1){name}}";
+
+            var expression = new TestQuery()
+                .IntValue(Var("var1"))
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void InputObject_Variable()
+        {
+            var expected = "query($var1:InputObject){inputObject(input:$var1){name}}";
+
+            var expression = new TestQuery()
+                .InputObject(Var("var1"))
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using Octokit.GraphQL.Core.Builders;
-using Octokit.GraphQL.Core.Serializers;
 using Octokit.GraphQL.Core.UnitTests.Models;
 using Xunit;
 using static Octokit.GraphQL.Variable;
@@ -18,10 +16,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("foo")
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -33,10 +30,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("foo", 2)
                 .Select(x => new { x.Name, x.Description });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -48,10 +44,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("foo")
                 .Select(x => x.Name + " World!");
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -63,10 +58,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("foo")
                 .Select(x => x.Name + x.Description);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -78,10 +72,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("foo")
                 .Select(x => x.Name + x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -96,10 +89,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Float = (DayOfWeek)x.Number
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -114,10 +106,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Float = (DayOfWeek)x.NullableNumber.Value
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -129,10 +120,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .QueryItems
                 .Select(x => x.Id);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -144,10 +134,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .QueryItems
                 .Select(x => new{ x.Id, x.Name});
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -160,10 +149,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple("bar")
                 .Select(x => new { x.Name, x.Description });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -179,10 +167,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Items = x.NestedItems.Select(i => i.Name).ToList(),
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -202,10 +189,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     }).Single()
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -222,20 +208,19 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Items = x.NestedItems.Select(i => i.Name).ToList(),
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
         public void Field_Aliases()
         {
             var expected = @"query {
-    simple(arg1: ""foo"", arg2: 1) {
-        foo: name
-        bar: description
-    }
+  simple(arg1: ""foo"", arg2: 1) {
+    foo: name
+    bar: description
+  }
 }";
 
             var expression = new TestQuery()
@@ -246,10 +231,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     Bar = x.Description,
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -261,10 +245,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .BoolValue(false)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -288,10 +271,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 })
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -303,10 +285,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .StringValue("hello")
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -318,10 +299,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .IntValue(123)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -333,10 +313,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .FloatValue(123.3f)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -348,10 +327,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .ObjectValue(null)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -368,10 +346,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .InputObject(input)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -388,10 +365,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .InputObject(input)
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         public class SampleObject
@@ -414,10 +390,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 })
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -433,13 +408,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 })
                 .Select(x => x.Name);
 
-            var querySerializer = new QuerySerializer();
-            var queryBuilder = new QueryBuilder();
+            var query = expression.Compile();
 
-            var query = queryBuilder.Build(expression);
-            var result = querySerializer.Serialize(query.OperationDefinition);
-
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
 
             expected = "query{objectValue(value:{value1:\"A different answer\",value2:14}){name}}";
 
@@ -451,23 +422,22 @@ namespace Octokit.GraphQL.Core.UnitTests
                 })
                 .Select(x => x.Name);
 
-            query = queryBuilder.Build(expression);
-            result = querySerializer.Serialize(query.OperationDefinition);
+            query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
         public void Union()
         {
             var expected = @"query {
-    union {
-        ... on Simple {
-            __typename
-            name
-            description
-        }
+  union {
+    ... on Simple {
+      __typename
+      name
+      description
     }
+  }
 }";
 
             var expression = new TestQuery()
@@ -479,44 +449,42 @@ namespace Octokit.GraphQL.Core.UnitTests
                     x.Description,
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
         public void Union_Select_Child_Property()
         {
             var expected = @"query {
-    union {
-        ... on Simple {
-            __typename
-            name
-        }
+  union {
+    ... on Simple {
+      __typename
+      name
     }
+  }
 }";
 
             var expression = new TestQuery()
                 .Union
                 .Select(x => x.Simple.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
         public void Union_Select_Child_Property_To_Class()
         {
             var expected = @"query {
-    union {
-        ... on Simple {
-            __typename
-            name
-        }
+  union {
+    ... on Simple {
+      __typename
+      name
     }
+  }
 }";
 
             var expression = new TestQuery()
@@ -526,10 +494,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                     x.Simple.Name,
                 });
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -541,10 +508,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .Simple(Var("var1"))
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -556,10 +522,9 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .IntValue(Var("var1"))
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
@@ -571,32 +536,30 @@ namespace Octokit.GraphQL.Core.UnitTests
                 .InputObject(Var("var1"))
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer().Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.Query);
         }
 
         [Fact]
         public void Interface_Cast()
         {
             var expected = @"query {
-    node(id: 123) {
-        ... on Simple {
-            __typename
-            name
-        }
+  node(id: 123) {
+    ... on Simple {
+      __typename
+      name
     }
+  }
 }";
             var expression = new TestQuery()
                 .Node(123)
                 .Cast<Simple>()
                 .Select(x => x.Name);
 
-            var query = new QueryBuilder().Build(expression);
-            var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Linq;
 using Octokit.GraphQL.Core.Builders;
 using Octokit.GraphQL.Core.Serializers;
 using Octokit.GraphQL.Core.UnitTests.Models;
 using Xunit;
+using static Octokit.GraphQL.Variable;
 
 namespace Octokit.GraphQL.Core.UnitTests
 {
@@ -528,6 +528,21 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = new QueryBuilder().Build(expression);
             var result = new QuerySerializer(4).Serialize(query.OperationDefinition);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void SimpleQuery_Variable()
+        {
+            var expected = "query($var1:String){simple(arg1:$var1){name}}";
+
+            var expression = new TestQuery()
+                .Simple(Var("var1"))
+                .Select(x => x.Name);
+
+            var query = new QueryBuilder().Build(expression);
+            var result = new QuerySerializer().Serialize(query.OperationDefinition);
 
             Assert.Equal(expected, result);
         }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -561,5 +561,19 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             Assert.Equal(expected, query.ToString());
         }
+
+        [Fact]
+        public void Multiple_Variables()
+        {
+            var expected = "query($foo:String,$bar:Int){simple(arg1:$foo,arg2:$bar){name}}";
+
+            var expression = new TestQuery()
+                .Simple(Var("foo"), Var("bar"))
+                .Select(x => x.Name);
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.Query);
+        }
     }
 }

--- a/Octokit.GraphQL.Core/CompiledQuery.cs
+++ b/Octokit.GraphQL.Core/CompiledQuery.cs
@@ -7,20 +7,24 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
-namespace Octokit.GraphQL.Core
+namespace Octokit.GraphQL
 {
-    public class GraphQLQuery<TResult>
+    public class CompiledQuery<TResult>
     {
-        public GraphQLQuery(
+        public CompiledQuery(
             OperationDefinition operationDefinition,
             Expression<Func<JObject, TResult>> expression)
         {
+            var serializer = new QuerySerializer();
             OperationDefinition = operationDefinition;
+            Query = serializer.Serialize(operationDefinition);
             Expression = expression;
             CompiledExpression = expression.Compile();
         }
 
         public OperationDefinition OperationDefinition { get; }
+
+        public string Query { get; }
 
         public Expression<Func<JObject, TResult>> Expression { get; }
 
@@ -33,10 +37,9 @@ namespace Octokit.GraphQL.Core
 
         public string GetPayload(IDictionary<string, object> variables)
         {
-            var query = new QuerySerializer().Serialize(OperationDefinition);
-            var payload = new
+           var payload = new
             {
-                Query = query,
+                Query,
                 Variables = variables,
             };
 

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -46,11 +46,13 @@ namespace Octokit.GraphQL
 
         public Uri Uri { get; }
 
-        public async Task<T> Run<T>(IQueryableValue<T> queryable)
+        public async Task<T> Run<T>(
+            IQueryableValue<T> queryable,
+            IDictionary<string, object> variables = null)
         {
             var builder = new QueryBuilder();
             var query = builder.Build(queryable);
-            var payload = query.GetPayload();
+            var payload = query.GetPayload(variables);
             var token = await credentialStore.GetCredentials();
             var request = new HttpRequestMessage(HttpMethod.Post, Uri);
             request.Content = new StringContent(payload);
@@ -61,11 +63,13 @@ namespace Octokit.GraphQL
             return deserializer.Deserialize(query, data);
         }
 
-        public async Task<IEnumerable<T>> Run<T>(IQueryableList<T> queryable)
+        public async Task<IEnumerable<T>> Run<T>(
+            IQueryableList<T> queryable,
+            IDictionary<string, object> variables = null)
         {
             var builder = new QueryBuilder();
             var query = builder.Build(queryable);
-            var payload = query.GetPayload();
+            var payload = query.GetPayload(variables);
             var token = await credentialStore.GetCredentials();
             var request = new HttpRequestMessage(HttpMethod.Post, Uri);
             request.Content = new StringContent(payload);

--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -47,28 +47,9 @@ namespace Octokit.GraphQL
         public Uri Uri { get; }
 
         public async Task<T> Run<T>(
-            IQueryableValue<T> queryable,
+            CompiledQuery<T> query,
             IDictionary<string, object> variables = null)
         {
-            var builder = new QueryBuilder();
-            var query = builder.Build(queryable);
-            var payload = query.GetPayload(variables);
-            var token = await credentialStore.GetCredentials();
-            var request = new HttpRequestMessage(HttpMethod.Post, Uri);
-            request.Content = new StringContent(payload);
-            request.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
-            var response = await httpClient.SendAsync(request);
-            var data = await response.Content.ReadAsStringAsync();
-            var deserializer = new ResponseDeserializer();
-            return deserializer.Deserialize(query, data);
-        }
-
-        public async Task<IEnumerable<T>> Run<T>(
-            IQueryableList<T> queryable,
-            IDictionary<string, object> variables = null)
-        {
-            var builder = new QueryBuilder();
-            var query = builder.Build(queryable);
             var payload = query.GetPayload(variables);
             var token = await credentialStore.GetCredentials();
             var request = new HttpRequestMessage(HttpMethod.Post, Uri);

--- a/Octokit.GraphQL.Core/ConnectionExtensions.cs
+++ b/Octokit.GraphQL.Core/ConnectionExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Octokit.GraphQL.Core;
+
+namespace Octokit.GraphQL
+{
+    public static class ConnectionExtensions
+    {
+        public static Task<T> Run<T>(
+            this Connection connection,
+            IQueryableValue<T> expression)
+        {
+            return connection.Run(expression.Compile());
+        }
+
+        public static Task<IEnumerable<T>> Run<T>(
+            this Connection connection,
+            IQueryableList<T> expression)
+        {
+            return connection.Run(expression.Compile());
+        }
+    }
+}

--- a/Octokit.GraphQL.Core/Core/Arg.cs
+++ b/Octokit.GraphQL.Core/Core/Arg.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Octokit.GraphQL.Core
+{
+    public struct Arg<T> : IArg
+    {
+        private Arg(string name, T value)
+        {
+            VariableName = name;
+            Value = value;
+        }
+
+        public string VariableName { get; }
+        public T Value { get; }
+        Type IArg.Type => typeof(T);
+        object IArg.Value => Value;
+
+        public static implicit operator Arg<T>(T value)
+        {
+            return new Arg<T>(null, value);
+        }
+
+        public static implicit operator Arg<T>(Variable variable)
+        {
+            return new Arg<T>(variable.Name, default(T));
+        }
+    }
+}

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -18,7 +18,7 @@ namespace Octokit.GraphQL.Core.Builders
         SyntaxTree syntax;
         Dictionary<ParameterExpression, LambdaParameter> lambdaParameters;
 
-        public GraphQLQuery<TResult> Build<TResult>(IQueryableValue<TResult> query)
+        public CompiledQuery<TResult> Build<TResult>(IQueryableValue<TResult> query)
         {
             root = null;
             syntax = new SyntaxTree();
@@ -28,10 +28,10 @@ namespace Octokit.GraphQL.Core.Builders
             var expression = Expression.Lambda<Func<JObject, TResult>>(
                 rewritten.AddCast(typeof(TResult)),
                 RootDataParameter);
-            return new GraphQLQuery<TResult>(root, expression);
+            return new CompiledQuery<TResult>(root, expression);
         }
 
-        public GraphQLQuery<IEnumerable<TResult>> Build<TResult>(IQueryableList<TResult> query)
+        public CompiledQuery<IEnumerable<TResult>> Build<TResult>(IQueryableList<TResult> query)
         {
             root = null;
             syntax = new SyntaxTree();
@@ -41,7 +41,7 @@ namespace Octokit.GraphQL.Core.Builders
             var expression = Expression.Lambda<Func<JObject, IEnumerable<TResult>>>(
                 rewritten.AddCast(typeof(IEnumerable<TResult>)),
                 RootDataParameter);
-            return new GraphQLQuery<IEnumerable<TResult>>(root, expression);
+            return new CompiledQuery<IEnumerable<TResult>>(root, expression);
         }
 
         protected override Expression VisitBinary(BinaryExpression node)

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -412,6 +412,18 @@ namespace Octokit.GraphQL.Core.Builders
                 var parameter = parameters[i];
                 var value = EvaluateValue(arguments[i]);
 
+                if (value is IArg arg)
+                {
+                    if (arg.VariableName == null)
+                    {
+                        value = arg.Value;
+                    }
+                    else
+                    {
+                        value = syntax.AddVariableDefinition(arg.Type, arg.VariableName);
+                    }
+                }
+
                 if (value != null)
                 {
                     syntax.AddArgument(parameter.Name, value);

--- a/Octokit.GraphQL.Core/Core/Deserializers/ResponseDeserializer.cs
+++ b/Octokit.GraphQL.Core/Core/Deserializers/ResponseDeserializer.cs
@@ -7,12 +7,12 @@ namespace Octokit.GraphQL.Core.Deserializers
 {
     public class ResponseDeserializer
     {
-        public TResult Deserialize<TResult>(GraphQLQuery<TResult> query, string data)
+        public TResult Deserialize<TResult>(CompiledQuery<TResult> query, string data)
         {
             return Deserialize(query, JObject.Parse(data));
         }
 
-        public TResult Deserialize<TResult>(GraphQLQuery<TResult> query, JObject data)
+        public TResult Deserialize<TResult>(CompiledQuery<TResult> query, JObject data)
         {
             if (data["errors"] != null)
             {

--- a/Octokit.GraphQL.Core/Core/GraphQLQuery.cs
+++ b/Octokit.GraphQL.Core/Core/GraphQLQuery.cs
@@ -31,12 +31,13 @@ namespace Octokit.GraphQL.Core
             return new QuerySerializer(2).Serialize(OperationDefinition);
         }
 
-        public string GetPayload()
+        public string GetPayload(IDictionary<string, object> variables)
         {
             var query = new QuerySerializer().Serialize(OperationDefinition);
             var payload = new
             {
                 Query = query,
+                Variables = variables,
             };
 
             return JsonConvert.SerializeObject(

--- a/Octokit.GraphQL.Core/Core/IArg.cs
+++ b/Octokit.GraphQL.Core/Core/IArg.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Octokit.GraphQL.Core
+{
+    internal interface IArg
+    {
+        Type Type { get; }
+        string VariableName { get; }
+        object Value { get; }
+    }
+}

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -62,6 +62,7 @@ namespace Octokit.GraphQL.Core.Serializers
                 {
                     if (!first) builder.Append(comma);
                     builder.Append('$').Append(v.Name).Append(colon).Append(v.Type);
+                    first = false;
                 }
 
                 builder.Append(')');

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -62,7 +62,7 @@ namespace Octokit.GraphQL.Core.Serializers
                 foreach (var v in operation.VariableDefinitions)
                 {
                     if (!first) builder.Append(comma);
-                    builder.Append('$').Append(v.Name).Append(colon).Append(v.Type.Name);
+                    builder.Append('$').Append(v.Name).Append(colon).Append(v.Type);
                 }
 
                 builder.Append(')');

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -54,6 +54,20 @@ namespace Octokit.GraphQL.Core.Serializers
                 builder.Append(' ').Append(operation.Name);
             }
 
+            if (operation.VariableDefinitions.Count > 0)
+            {
+                builder.Append('(');
+
+                var first = true;
+                foreach (var v in operation.VariableDefinitions)
+                {
+                    if (!first) builder.Append(comma);
+                    builder.Append('$').Append(v.Name).Append(colon).Append(v.Type.Name);
+                }
+
+                builder.Append(')');
+            }
+
             SerializeSelections(operation, builder);
             return builder.ToString();
         }
@@ -174,6 +188,10 @@ namespace Octokit.GraphQL.Core.Serializers
 
                 builder.Append("]");
             }
+            else if (value is VariableDefinition v)
+            {
+                builder.Append('$').Append(v.Name);
+            }
             else
             {
                 var objectType = value.GetType();
@@ -196,7 +214,7 @@ namespace Octokit.GraphQL.Core.Serializers
                 for (var index = 0; index < properties.Length; index++)
                 {
                     var property = properties[index];
-                    
+
                     if (index == 0)
                     {
                         OpenBrace(builder);

--- a/Octokit.GraphQL.Core/Core/Syntax/OperationDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/OperationDefinition.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Octokit.GraphQL.Core.Syntax
 {
@@ -8,9 +9,11 @@ namespace Octokit.GraphQL.Core.Syntax
         {
             Type = type;
             Name = name;
+            VariableDefinitions = new List<VariableDefinition>();
         }
 
         public OperationType Type { get; }
         public string Name { get; }
+        public IList<VariableDefinition> VariableDefinitions { get; }
     }
 }

--- a/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
@@ -54,7 +54,7 @@ namespace Octokit.GraphQL.Core.Syntax
         {
             var result = root.VariableDefinitions.SingleOrDefault(x => x.Name == name);
 
-            if (result != null && result.Type != type)
+            if (result != null && result.Type != VariableDefinition.ToTypeName(type))
             {
                 throw new InvalidOperationException(
                     $"A variable called '{name}' has already been added with a different type.");

--- a/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
@@ -50,6 +50,21 @@ namespace Octokit.GraphQL.Core.Syntax
             return result;
         }
 
+        public VariableDefinition AddVariableDefinition(Type type, string name)
+        {
+            var result = root.VariableDefinitions.SingleOrDefault(x => x.Name == name);
+
+            if (result != null && result.Type != type)
+            {
+                throw new InvalidOperationException(
+                    $"A variable called '{name}' has already been added with a different type.");
+            }
+
+            result = result ?? new VariableDefinition(type, name);
+            root.VariableDefinitions.Add(result);
+            return result;
+        }
+
         public IDisposable Bookmark()
         {
             var oldHead = head;

--- a/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Octokit.GraphQL.Core.Syntax
+{
+    public class VariableDefinition
+    {
+        public VariableDefinition(Type type, string name)
+        {
+            Type = type;
+            Name = name;
+        }
+
+        public Type Type { get; }
+        public string Name { get; }
+    }
+}

--- a/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
@@ -8,11 +8,29 @@ namespace Octokit.GraphQL.Core.Syntax
     {
         public VariableDefinition(Type type, string name)
         {
-            Type = type;
+            Type = ToTypeName(type);
             Name = name;
         }
 
-        public Type Type { get; }
+        public string Type { get; }
         public string Name { get; }
+
+        public static string ToTypeName(Type type)
+        {
+            if (type == typeof(int))
+            {
+                return "Int";
+            }
+            else if (type == typeof(double))
+            {
+                return "Float";
+            }
+            else if (type == typeof(bool))
+            {
+                return "Boolean";
+            }
+
+            return type.Name;
+        }
     }
 }

--- a/Octokit.GraphQL.Core/QueryableListExtensions.cs
+++ b/Octokit.GraphQL.Core/QueryableListExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Octokit.GraphQL.Core;
+using Octokit.GraphQL.Core.Builders;
 using Octokit.GraphQL.Internal;
 
 namespace Octokit.GraphQL
@@ -54,6 +55,11 @@ namespace Octokit.GraphQL
         public static IList<TValue> ToList<TValue>(this IQueryableList<TValue> source)
         {
             throw new NotImplementedException();
+        }
+
+        public static CompiledQuery<IEnumerable<T>> Compile<T>(this IQueryableList<T> expression)
+        {
+            return new QueryBuilder().Build(expression);
         }
 
         private static MethodInfo GetMethodInfo(string id)

--- a/Octokit.GraphQL.Core/QueryableValueExtensions.cs
+++ b/Octokit.GraphQL.Core/QueryableValueExtensions.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Octokit.GraphQL.Core;
+using Octokit.GraphQL.Core.Builders;
 using Octokit.GraphQL.Internal;
 
 namespace Octokit.GraphQL
@@ -54,6 +55,11 @@ namespace Octokit.GraphQL
         public static TValue SingleOrDefault<TValue>(this IQueryableValue<TValue> source)
         {
             throw new NotImplementedException();
+        }
+
+        public static CompiledQuery<T> Compile<T>(this IQueryableValue<T> expression)
+        {
+            return new QueryBuilder().Build(expression);
         }
 
         private static MethodInfo GetMethodInfo(string id)

--- a/Octokit.GraphQL.Core/Variable.cs
+++ b/Octokit.GraphQL.Core/Variable.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Octokit.GraphQL
+{
+    public struct Variable
+    {
+        private Variable(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public static Variable Var(string name)
+        {
+            return new Variable(name);
+        }
+    }
+}

--- a/Octokit.GraphQL.Core/Variable.cs
+++ b/Octokit.GraphQL.Core/Variable.cs
@@ -4,7 +4,7 @@ namespace Octokit.GraphQL
 {
     public struct Variable
     {
-        private Variable(string name)
+        public Variable(string name)
         {
             Name = name;
         }

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -64,7 +64,8 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 { "first", 3 }
             };
 
-            var results = Connection.Run(query, vars).Result.ToArray();
+            var compiled = query.Compile();
+            var results = Connection.Run(compiled, vars).Result.ToArray();
             Assert.Equal(3, results.Length);
         }
 

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Linq;
 using Octokit.GraphQL.IntegrationTests.Utilities;
 using Octokit.GraphQL.Model;
 using Xunit;
+using static Octokit.GraphQL.Variable;
 
 namespace Octokit.GraphQL.IntegrationTests.Queries
 {
@@ -40,6 +42,30 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 Assert.Equal("octokit.net", result.RepositoryName);
                 Assert.Equal(IssueState.Closed, result.State);
             }
+        }
+
+        [IntegrationTest]
+        public void Should_Query_Issues_With_Variable()
+        {
+            var openState = new[] { IssueState.Closed };
+            var query = new Query()
+                .Repository("octokit", "octokit.net")
+                .Issues(Var("first"), states: openState)
+                .Nodes
+                .Select(i => new
+            {
+                i.Title,
+                i.State,
+                RepositoryName = i.Repository.Name,
+            });
+
+            var vars = new Dictionary<string, object>
+            {
+                { "first", 3 }
+            };
+
+            var results = Connection.Run(query, vars).Result.ToArray();
+            Assert.Equal(3, results.Length);
         }
 
         [IntegrationTest(Skip = "Querying unions like this no longer works")]

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -26,7 +26,7 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         [IntegrationTest]
         public void Should_Query_Issues_By_State_And_Repository()
         {
-            var openState = new[] { IssueState.Closed }.AsQueryable();
+            var openState = new[] { IssueState.Closed };
             var query = new GraphQL.Query().Repository("octokit", "octokit.net").Issues(first: 3, states: openState).Nodes.Select(i => new
             {
                 i.Title,

--- a/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Linq;
-using Octokit.GraphQL.Core;
-using Octokit.GraphQL.Core.Builders;
-using Octokit.GraphQL.Core.Serializers;
 using Octokit.GraphQL.Model;
 using Xunit;
 
@@ -42,10 +38,9 @@ namespace Octokit.GraphQL.UnitTests
                     x.IsPrivate,
                 });
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -86,10 +81,9 @@ namespace Octokit.GraphQL.UnitTests
                     x.IsPrivate,
                 });
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -138,10 +132,9 @@ namespace Octokit.GraphQL.UnitTests
                         root.Viewer.Email
                     }));
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -180,10 +173,9 @@ namespace Octokit.GraphQL.UnitTests
                     }).ToList(),
                 });
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -198,10 +190,9 @@ namespace Octokit.GraphQL.UnitTests
 
             var expression = new Query().Viewer.Select(x => new { x.Login, x.Email });
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -238,10 +229,9 @@ namespace Octokit.GraphQL.UnitTests
                                   }).Single()
                               }));
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -263,10 +253,9 @@ namespace Octokit.GraphQL.UnitTests
                 .Nodes
                 .Select(x => x.User.Name);
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact]
@@ -294,10 +283,9 @@ namespace Octokit.GraphQL.UnitTests
                     x.Login,
                 });
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
 
         [Fact(Skip = "Not yet working")]
@@ -321,10 +309,9 @@ namespace Octokit.GraphQL.UnitTests
                 .Edges.Select(x => x.Node)
                 .Select(x => x.User.Name);
 
-            var serializer = new QuerySerializer(2);
-            var result = serializer.Serialize(new QueryBuilder().Build(expression).OperationDefinition);
+            var query = expression.Compile();
 
-            Assert.Equal(expected, result);
+            Assert.Equal(expected, query.ToString());
         }
     }
 }

--- a/Octokit.GraphQL/Model/Actor.cs
+++ b/Octokit.GraphQL/Model/Actor.cs
@@ -17,7 +17,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the actor's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        string AvatarUrl(int? size = null);
+        string AvatarUrl(Arg<int>? size = null);
 
         /// <summary>
         /// The username of the actor.
@@ -50,7 +50,7 @@ namespace Octokit.GraphQL.Model.Internal
         {
         }
 
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         public string Login { get; }
 

--- a/Octokit.GraphQL/Model/Assignable.cs
+++ b/Octokit.GraphQL/Model/Assignable.cs
@@ -20,7 +20,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        UserConnection Assignees(int? first = null, string after = null, int? last = null, string before = null);
+        UserConnection Assignees(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null);
     }
 }
 
@@ -38,7 +38,7 @@ namespace Octokit.GraphQL.Model.Internal
         {
         }
 
-        public UserConnection Assignees(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Assignees(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         internal static StubIAssignable Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/Bot.cs
+++ b/Octokit.GraphQL/Model/Bot.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the GitHub App's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// Identifies the date and time when the object was created.

--- a/Octokit.GraphQL/Model/ClosedEvent.cs
+++ b/Octokit.GraphQL/Model/ClosedEvent.cs
@@ -33,7 +33,7 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Identifies the commit associated with the 'closed' event.
         /// </summary>
-        [Obsolete(@"Use ClosedEvent.closer instead.")]
+        [Obsolete(@"`ClosedEvent` may be associated with other objects than a commit. Use ClosedEvent.closer instead. Removal on 2018-07-01 UTC.")]
         public Commit Commit => this.CreateProperty(x => x.Commit, Octokit.GraphQL.Model.Commit.Create);
 
         /// <summary>

--- a/Octokit.GraphQL/Model/Comment.cs
+++ b/Octokit.GraphQL/Model/Comment.cs
@@ -66,6 +66,15 @@ namespace Octokit.GraphQL.Model
         DateTimeOffset? UpdatedAt { get; }
 
         /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null);
+
+        /// <summary>
         /// Did the viewer author this comment.
         /// </summary>
         bool ViewerDidAuthor { get; }
@@ -108,6 +117,8 @@ namespace Octokit.GraphQL.Model.Internal
 
         [Obsolete(@"General type updated timestamps will eventually be replaced by other field specific timestamps.")]
         public DateTimeOffset? UpdatedAt { get; }
+
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         public bool ViewerDidAuthor { get; }
 

--- a/Octokit.GraphQL/Model/Comment.cs
+++ b/Octokit.GraphQL/Model/Comment.cs
@@ -11,7 +11,7 @@ namespace Octokit.GraphQL.Model
     /// <summary>
     /// Represents a comment.
     /// </summary>
-    public interface IComment : IQueryableValue<IComment>
+    public interface IComment : IQueryableValue<IComment>, IQueryableInterface
     {
         /// <summary>
         /// The actor who authored the comment.

--- a/Octokit.GraphQL/Model/Commit.cs
+++ b/Octokit.GraphQL/Model/Commit.cs
@@ -44,7 +44,7 @@ namespace Octokit.GraphQL.Model
         /// Fetches `git blame` information.
         /// </summary>
         /// <param name="path">The file whose Git blame information you want.</param>
-        public Blame Blame(string path) => this.CreateMethodCall(x => x.Blame(path), Octokit.GraphQL.Model.Blame.Create);
+        public Blame Blame(Arg<string> path) => this.CreateMethodCall(x => x.Blame(path), Octokit.GraphQL.Model.Blame.Create);
 
         /// <summary>
         /// The number of changed files in this commit.
@@ -58,7 +58,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public CommitCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
+        public CommitCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
 
         /// <summary>
         /// The HTTP path for this Git object
@@ -101,7 +101,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="author">If non-null, filters history to only show commits with matching authorship.</param>
         /// <param name="since">Allows specifying a beginning time or date for fetching commits.</param>
         /// <param name="until">Allows specifying an ending time or date for fetching commits.</param>
-        public CommitHistoryConnection History(int? first = null, string after = null, int? last = null, string before = null, string path = null, CommitAuthor author = null, string since = null, string until = null) => this.CreateMethodCall(x => x.History(first, after, last, before, path, author, since, until), Octokit.GraphQL.Model.CommitHistoryConnection.Create);
+        public CommitHistoryConnection History(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<string>? path = null, Arg<CommitAuthor>? author = null, Arg<string>? since = null, Arg<string>? until = null) => this.CreateMethodCall(x => x.History(first, after, last, before, path, author, since, until), Octokit.GraphQL.Model.CommitHistoryConnection.Create);
 
         public string Id { get; }
 
@@ -142,7 +142,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public CommitConnection Parents(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Parents(first, after, last, before), Octokit.GraphQL.Model.CommitConnection.Create);
+        public CommitConnection Parents(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Parents(first, after, last, before), Octokit.GraphQL.Model.CommitConnection.Create);
 
         /// <summary>
         /// The datetime when this commit was pushed.

--- a/Octokit.GraphQL/Model/CommitComment.cs
+++ b/Octokit.GraphQL/Model/CommitComment.cs
@@ -97,7 +97,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         /// <summary>
         /// The repository associated with this node.
@@ -119,6 +119,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL permalink for this commit comment.
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Check if the current viewer can delete this object.

--- a/Octokit.GraphQL/Model/CommitCommentThread.cs
+++ b/Octokit.GraphQL/Model/CommitCommentThread.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public CommitCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
+        public CommitCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
 
         /// <summary>
         /// The commit the comments were made on.

--- a/Octokit.GraphQL/Model/Deployment.cs
+++ b/Octokit.GraphQL/Model/Deployment.cs
@@ -70,7 +70,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public DeploymentStatusConnection Statuses(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Statuses(first, after, last, before), Octokit.GraphQL.Model.DeploymentStatusConnection.Create);
+        public DeploymentStatusConnection Statuses(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Statuses(first, after, last, before), Octokit.GraphQL.Model.DeploymentStatusConnection.Create);
 
         internal static Deployment Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/Gist.cs
+++ b/Octokit.GraphQL/Model/Gist.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public GistCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.GistCommentConnection.Create);
+        public GistCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.GistCommentConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -64,7 +64,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="orderBy">Order for connection</param>
-        public StargazerConnection Stargazers(int? first = null, string after = null, int? last = null, string before = null, StarOrder orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
+        public StargazerConnection Stargazers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<StarOrder>? orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was last updated.

--- a/Octokit.GraphQL/Model/GistComment.cs
+++ b/Octokit.GraphQL/Model/GistComment.cs
@@ -74,6 +74,15 @@ namespace Octokit.GraphQL.Model
         public DateTimeOffset? UpdatedAt { get; }
 
         /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
+
+        /// <summary>
         /// Check if the current viewer can delete this object.
         /// </summary>
         public bool ViewerCanDelete { get; }

--- a/Octokit.GraphQL/Model/GitActor.cs
+++ b/Octokit.GraphQL/Model/GitActor.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the author's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// The timestamp of the Git action (authoring or committing).

--- a/Octokit.GraphQL/Model/Issue.cs
+++ b/Octokit.GraphQL/Model/Issue.cs
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Assignees(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Assignees(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// The actor who authored the comment.
@@ -71,7 +71,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public IssueCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
+        public IssueCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -103,7 +103,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public LabelConnection Labels(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
+        public LabelConnection Labels(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
 
         /// <summary>
         /// The moment the editor made the last edit
@@ -132,7 +132,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Participants(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Participants(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Participants(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Participants(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// List of project cards associated with this issue.
@@ -141,7 +141,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProjectCardConnection ProjectCards(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ProjectCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
+        public ProjectCardConnection ProjectCards(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ProjectCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
 
         /// <summary>
         /// Identifies when the comment was published at.
@@ -162,7 +162,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         /// <summary>
         /// The repository associated with this node.
@@ -187,7 +187,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="since">Allows filtering timeline events by a `since` timestamp.</param>
-        public IssueTimelineConnection Timeline(int? first = null, string after = null, int? last = null, string before = null, DateTimeOffset? since = null) => this.CreateMethodCall(x => x.Timeline(first, after, last, before, since), Octokit.GraphQL.Model.IssueTimelineConnection.Create);
+        public IssueTimelineConnection Timeline(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<DateTimeOffset>? since = null) => this.CreateMethodCall(x => x.Timeline(first, after, last, before, since), Octokit.GraphQL.Model.IssueTimelineConnection.Create);
 
         /// <summary>
         /// Identifies the issue title.
@@ -204,6 +204,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL for this issue
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Can user react to this subject

--- a/Octokit.GraphQL/Model/IssueComment.cs
+++ b/Octokit.GraphQL/Model/IssueComment.cs
@@ -98,7 +98,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         /// <summary>
         /// The repository associated with this node.
@@ -120,6 +120,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL for this issue comment
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Check if the current viewer can delete this object.

--- a/Octokit.GraphQL/Model/Label.cs
+++ b/Octokit.GraphQL/Model/Label.cs
@@ -32,7 +32,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="labels">A list of label names to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for issues returned from the connection.</param>
         /// <param name="states">A list of states to filter the issues by.</param>
-        public IssueConnection Issues(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<string> labels = null, IssueOrder orderBy = null, IEnumerable<IssueState> states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
+        public IssueConnection Issues(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? labels = null, Arg<IssueOrder>? orderBy = null, Arg<IEnumerable<IssueState>>? states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
 
         /// <summary>
         /// Identifies the label name.
@@ -51,7 +51,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="headRefName">The head ref name to filter the pull requests by.</param>
         /// <param name="baseRefName">The base ref name to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for pull requests returned from the connection.</param>
-        public PullRequestConnection PullRequests(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestState> states = null, IEnumerable<string> labels = null, string headRefName = null, string baseRefName = null, IssueOrder orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
+        public PullRequestConnection PullRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestState>>? states = null, Arg<IEnumerable<string>>? labels = null, Arg<string>? headRefName = null, Arg<string>? baseRefName = null, Arg<IssueOrder>? orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
 
         /// <summary>
         /// The repository associated with this label.

--- a/Octokit.GraphQL/Model/Labelable.cs
+++ b/Octokit.GraphQL/Model/Labelable.cs
@@ -20,7 +20,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        LabelConnection Labels(int? first = null, string after = null, int? last = null, string before = null);
+        LabelConnection Labels(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null);
     }
 }
 
@@ -38,7 +38,7 @@ namespace Octokit.GraphQL.Model.Internal
         {
         }
 
-        public LabelConnection Labels(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
+        public LabelConnection Labels(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
 
         internal static StubILabelable Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/MarketplaceListing.cs
+++ b/Octokit.GraphQL/Model/MarketplaceListing.cs
@@ -126,7 +126,7 @@ namespace Octokit.GraphQL.Model
         /// URL for the listing's logo image.
         /// </summary>
         /// <param name="size">The size in pixels of the resulting square image.</param>
-        public string LogoUrl(int? size = 400) => null;
+        public string LogoUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// The listing's full name.

--- a/Octokit.GraphQL/Model/Milestone.cs
+++ b/Octokit.GraphQL/Model/Milestone.cs
@@ -57,7 +57,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="labels">A list of label names to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for issues returned from the connection.</param>
         /// <param name="states">A list of states to filter the issues by.</param>
-        public IssueConnection Issues(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<string> labels = null, IssueOrder orderBy = null, IEnumerable<IssueState> states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
+        public IssueConnection Issues(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? labels = null, Arg<IssueOrder>? orderBy = null, Arg<IEnumerable<IssueState>>? states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
 
         /// <summary>
         /// Identifies the number of the milestone.
@@ -76,7 +76,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="headRefName">The head ref name to filter the pull requests by.</param>
         /// <param name="baseRefName">The base ref name to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for pull requests returned from the connection.</param>
-        public PullRequestConnection PullRequests(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestState> states = null, IEnumerable<string> labels = null, string headRefName = null, string baseRefName = null, IssueOrder orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
+        public PullRequestConnection PullRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestState>>? states = null, Arg<IEnumerable<string>>? labels = null, Arg<string>? headRefName = null, Arg<string>? baseRefName = null, Arg<IssueOrder>? orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
 
         /// <summary>
         /// The repository associated with this milestone.

--- a/Octokit.GraphQL/Model/Organization.cs
+++ b/Octokit.GraphQL/Model/Organization.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the organization's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// Identifies the primary key from the database.
@@ -56,7 +56,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Members(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Members(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Members(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Members(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// The organization's public profile name.
@@ -89,13 +89,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        public RepositoryConnection PinnedRepositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection PinnedRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// Find project by number.
         /// </summary>
         /// <param name="number">The project number to find.</param>
-        public Project Project(int number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
+        public Project Project(Arg<int> number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
 
         /// <summary>
         /// A list of projects under the owner.
@@ -107,7 +107,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for projects returned from the connection</param>
         /// <param name="search">Query to search projects by, currently only searching by name.</param>
         /// <param name="states">A list of states to filter the projects by.</param>
-        public ProjectConnection Projects(int? first = null, string after = null, int? last = null, string before = null, ProjectOrder orderBy = null, string search = null, IEnumerable<ProjectState> states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
+        public ProjectConnection Projects(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ProjectOrder>? orderBy = null, Arg<string>? search = null, Arg<IEnumerable<ProjectState>>? states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
 
         /// <summary>
         /// The HTTP path listing organization's projects
@@ -131,13 +131,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
         /// <param name="isFork">If non-null, filters repositories according to whether they are forks of another repository</param>
-        public RepositoryConnection Repositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null, bool? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null, Arg<bool>? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// Find Repository.
         /// </summary>
         /// <param name="name">Name of Repository to find.</param>
-        public Repository Repository(string name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
+        public Repository Repository(Arg<string> name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
 
         /// <summary>
         /// The HTTP path for this user
@@ -153,7 +153,7 @@ namespace Octokit.GraphQL.Model
         /// Find an organization's team by its slug.
         /// </summary>
         /// <param name="slug">The name or slug of the team to find.</param>
-        public Team Team(string slug) => this.CreateMethodCall(x => x.Team(slug), Octokit.GraphQL.Model.Team.Create);
+        public Team Team(Arg<string> slug) => this.CreateMethodCall(x => x.Team(slug), Octokit.GraphQL.Model.Team.Create);
 
         /// <summary>
         /// A list of teams in this organization.
@@ -169,7 +169,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for teams returned from the connection</param>
         /// <param name="ldapMapped">If true, filters teams that are mapped to an LDAP Group (Enterprise only)</param>
         /// <param name="rootTeamsOnly">If true, restrict to only root teams</param>
-        public TeamConnection Teams(int? first = null, string after = null, int? last = null, string before = null, TeamPrivacy? privacy = null, TeamRole? role = null, string query = null, IEnumerable<string> userLogins = null, TeamOrder orderBy = null, bool? ldapMapped = null, bool? rootTeamsOnly = false) => this.CreateMethodCall(x => x.Teams(first, after, last, before, privacy, role, query, userLogins, orderBy, ldapMapped, rootTeamsOnly), Octokit.GraphQL.Model.TeamConnection.Create);
+        public TeamConnection Teams(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<TeamPrivacy>? privacy = null, Arg<TeamRole>? role = null, Arg<string>? query = null, Arg<IEnumerable<string>>? userLogins = null, Arg<TeamOrder>? orderBy = null, Arg<bool>? ldapMapped = null, Arg<bool>? rootTeamsOnly = null) => this.CreateMethodCall(x => x.Teams(first, after, last, before, privacy, role, query, userLogins, orderBy, ldapMapped, rootTeamsOnly), Octokit.GraphQL.Model.TeamConnection.Create);
 
         /// <summary>
         /// The HTTP path listing organization's teams

--- a/Octokit.GraphQL/Model/OrganizationIdentityProvider.cs
+++ b/Octokit.GraphQL/Model/OrganizationIdentityProvider.cs
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ExternalIdentityConnection ExternalIdentities(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ExternalIdentities(first, after, last, before), Octokit.GraphQL.Model.ExternalIdentityConnection.Create);
+        public ExternalIdentityConnection ExternalIdentities(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ExternalIdentities(first, after, last, before), Octokit.GraphQL.Model.ExternalIdentityConnection.Create);
 
         public string Id { get; }
 

--- a/Octokit.GraphQL/Model/OrganizationInvitation.cs
+++ b/Octokit.GraphQL/Model/OrganizationInvitation.cs
@@ -16,6 +16,11 @@ namespace Octokit.GraphQL.Model
         }
 
         /// <summary>
+        /// Identifies the date and time when the object was created.
+        /// </summary>
+        public DateTimeOffset? CreatedAt { get; }
+
+        /// <summary>
         /// The email address of the user invited to the organization.
         /// </summary>
         public string Email { get; }
@@ -36,6 +41,11 @@ namespace Octokit.GraphQL.Model
         /// The user who created the invitation.
         /// </summary>
         public User Inviter => this.CreateProperty(x => x.Inviter, Octokit.GraphQL.Model.User.Create);
+
+        /// <summary>
+        /// The organization the invite is for
+        /// </summary>
+        public Organization Organization => this.CreateProperty(x => x.Organization, Octokit.GraphQL.Model.Organization.Create);
 
         /// <summary>
         /// The user's pending role in the organization (e.g. member, owner).

--- a/Octokit.GraphQL/Model/Project.cs
+++ b/Octokit.GraphQL/Model/Project.cs
@@ -42,7 +42,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProjectColumnConnection Columns(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Columns(first, after, last, before), Octokit.GraphQL.Model.ProjectColumnConnection.Create);
+        public ProjectColumnConnection Columns(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Columns(first, after, last, before), Octokit.GraphQL.Model.ProjectColumnConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -84,7 +84,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProjectCardConnection PendingCards(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.PendingCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
+        public ProjectCardConnection PendingCards(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.PendingCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
 
         /// <summary>
         /// The HTTP path for this project

--- a/Octokit.GraphQL/Model/ProjectColumn.cs
+++ b/Octokit.GraphQL/Model/ProjectColumn.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProjectCardConnection Cards(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Cards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
+        public ProjectCardConnection Cards(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Cards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.

--- a/Octokit.GraphQL/Model/ProjectOwner.cs
+++ b/Octokit.GraphQL/Model/ProjectOwner.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Model
         /// Find project by number.
         /// </summary>
         /// <param name="number">The project number to find.</param>
-        Project Project(int number);
+        Project Project(Arg<int> number);
 
         /// <summary>
         /// A list of projects under the owner.
@@ -31,7 +31,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for projects returned from the connection</param>
         /// <param name="search">Query to search projects by, currently only searching by name.</param>
         /// <param name="states">A list of states to filter the projects by.</param>
-        ProjectConnection Projects(int? first = null, string after = null, int? last = null, string before = null, ProjectOrder orderBy = null, string search = null, IEnumerable<ProjectState> states = null);
+        ProjectConnection Projects(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ProjectOrder>? orderBy = null, Arg<string>? search = null, Arg<IEnumerable<ProjectState>>? states = null);
 
         /// <summary>
         /// The HTTP path listing owners projects
@@ -66,9 +66,9 @@ namespace Octokit.GraphQL.Model.Internal
 
         public string Id { get; }
 
-        public Project Project(int number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
+        public Project Project(Arg<int> number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
 
-        public ProjectConnection Projects(int? first = null, string after = null, int? last = null, string before = null, ProjectOrder orderBy = null, string search = null, IEnumerable<ProjectState> states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
+        public ProjectConnection Projects(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ProjectOrder>? orderBy = null, Arg<string>? search = null, Arg<IEnumerable<ProjectState>>? states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
 
         public string ProjectsResourcePath { get; }
 

--- a/Octokit.GraphQL/Model/ProtectedBranch.cs
+++ b/Octokit.GraphQL/Model/ProtectedBranch.cs
@@ -69,7 +69,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public PushAllowanceConnection PushAllowances(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.PushAllowances(first, after, last, before), Octokit.GraphQL.Model.PushAllowanceConnection.Create);
+        public PushAllowanceConnection PushAllowances(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.PushAllowances(first, after, last, before), Octokit.GraphQL.Model.PushAllowanceConnection.Create);
 
         /// <summary>
         /// The repository associated with this protected branch.
@@ -88,7 +88,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ReviewDismissalAllowanceConnection ReviewDismissalAllowances(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ReviewDismissalAllowances(first, after, last, before), Octokit.GraphQL.Model.ReviewDismissalAllowanceConnection.Create);
+        public ReviewDismissalAllowanceConnection ReviewDismissalAllowances(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ReviewDismissalAllowances(first, after, last, before), Octokit.GraphQL.Model.ReviewDismissalAllowanceConnection.Create);
 
         internal static ProtectedBranch Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/PullRequest.cs
+++ b/Octokit.GraphQL/Model/PullRequest.cs
@@ -32,7 +32,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Assignees(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Assignees(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Assignees(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// The actor who authored the comment.
@@ -96,7 +96,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public IssueCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
+        public IssueCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
 
         /// <summary>
         /// A list of commits present in this pull request's head branch not present in the base branch.
@@ -105,7 +105,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public PullRequestCommitConnection Commits(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Commits(first, after, last, before), Octokit.GraphQL.Model.PullRequestCommitConnection.Create);
+        public PullRequestCommitConnection Commits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Commits(first, after, last, before), Octokit.GraphQL.Model.PullRequestCommitConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -172,7 +172,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public LabelConnection Labels(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
+        public LabelConnection Labels(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
 
         /// <summary>
         /// The moment the editor made the last edit
@@ -221,7 +221,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Participants(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Participants(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Participants(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Participants(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// The commit that GitHub automatically generated to test if this pull request could be merged. This field will not return a value if the pull request is merged, or if the test merge commit is still being generated. See the `mergeable` field for more details on the mergeability of the pull request.
@@ -235,7 +235,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProjectCardConnection ProjectCards(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ProjectCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
+        public ProjectCardConnection ProjectCards(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ProjectCards(first, after, last, before), Octokit.GraphQL.Model.ProjectCardConnection.Create);
 
         /// <summary>
         /// Identifies when the comment was published at.
@@ -256,7 +256,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         /// <summary>
         /// The repository associated with this node.
@@ -285,7 +285,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ReviewRequestConnection ReviewRequests(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ReviewRequests(first, after, last, before), Octokit.GraphQL.Model.ReviewRequestConnection.Create);
+        public ReviewRequestConnection ReviewRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ReviewRequests(first, after, last, before), Octokit.GraphQL.Model.ReviewRequestConnection.Create);
 
         /// <summary>
         /// A list of reviews associated with the pull request.
@@ -296,7 +296,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="states">A list of states to filter the reviews.</param>
         /// <param name="author">Filter by author of the review.</param>
-        public PullRequestReviewConnection Reviews(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestReviewState> states = null, string author = null) => this.CreateMethodCall(x => x.Reviews(first, after, last, before, states, author), Octokit.GraphQL.Model.PullRequestReviewConnection.Create);
+        public PullRequestReviewConnection Reviews(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestReviewState>>? states = null, Arg<string>? author = null) => this.CreateMethodCall(x => x.Reviews(first, after, last, before, states, author), Octokit.GraphQL.Model.PullRequestReviewConnection.Create);
 
         /// <summary>
         /// Identifies the state of the pull request.
@@ -316,7 +316,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="since">Allows filtering timeline events by a `since` timestamp.</param>
-        public PullRequestTimelineConnection Timeline(int? first = null, string after = null, int? last = null, string before = null, DateTimeOffset? since = null) => this.CreateMethodCall(x => x.Timeline(first, after, last, before, since), Octokit.GraphQL.Model.PullRequestTimelineConnection.Create);
+        public PullRequestTimelineConnection Timeline(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<DateTimeOffset>? since = null) => this.CreateMethodCall(x => x.Timeline(first, after, last, before, since), Octokit.GraphQL.Model.PullRequestTimelineConnection.Create);
 
         /// <summary>
         /// Identifies the pull request title.
@@ -333,6 +333,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL for this pull request.
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Can user react to this subject

--- a/Octokit.GraphQL/Model/PullRequestReview.cs
+++ b/Octokit.GraphQL/Model/PullRequestReview.cs
@@ -47,7 +47,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public PullRequestReviewCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.PullRequestReviewCommentConnection.Create);
+        public PullRequestReviewCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.PullRequestReviewCommentConnection.Create);
 
         /// <summary>
         /// Identifies the commit associated with this pull request review.
@@ -122,6 +122,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL permalink for this PullRequestReview.
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Check if the current viewer can delete this object.

--- a/Octokit.GraphQL/Model/PullRequestReviewComment.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewComment.cs
@@ -132,7 +132,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         /// <summary>
         /// The comment this is a reply to.
@@ -158,6 +158,15 @@ namespace Octokit.GraphQL.Model
         /// The HTTP URL permalink for this review comment.
         /// </summary>
         public string Url { get; }
+
+        /// <summary>
+        /// A list of edits to this content.
+        /// </summary>
+        /// <param name="first">Returns the first _n_ elements from the list.</param>
+        /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
+        /// <param name="last">Returns the last _n_ elements from the list.</param>
+        /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
+        public UserContentEditConnection UserContentEdits(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.UserContentEdits(first, after, last, before), Octokit.GraphQL.Model.UserContentEditConnection.Create);
 
         /// <summary>
         /// Check if the current viewer can delete this object.

--- a/Octokit.GraphQL/Model/PullRequestReviewThread.cs
+++ b/Octokit.GraphQL/Model/PullRequestReviewThread.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public PullRequestReviewCommentConnection Comments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.PullRequestReviewCommentConnection.Create);
+        public PullRequestReviewCommentConnection Comments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Comments(first, after, last, before), Octokit.GraphQL.Model.PullRequestReviewCommentConnection.Create);
 
         public string Id { get; }
 

--- a/Octokit.GraphQL/Model/Reactable.cs
+++ b/Octokit.GraphQL/Model/Reactable.cs
@@ -34,7 +34,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="content">Allows filtering Reactions by emoji.</param>
         /// <param name="orderBy">Allows specifying the order in which reactions are returned.</param>
-        ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null);
+        ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null);
 
         /// <summary>
         /// Can user react to this subject
@@ -64,7 +64,7 @@ namespace Octokit.GraphQL.Model.Internal
 
         public IQueryableList<ReactionGroup> ReactionGroups => this.CreateProperty(x => x.ReactionGroups);
 
-        public ReactionConnection Reactions(int? first = null, string after = null, int? last = null, string before = null, ReactionContent? content = null, ReactionOrder orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
+        public ReactionConnection Reactions(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReactionContent>? content = null, Arg<ReactionOrder>? orderBy = null) => this.CreateMethodCall(x => x.Reactions(first, after, last, before, content, orderBy), Octokit.GraphQL.Model.ReactionConnection.Create);
 
         public bool ViewerCanReact { get; }
 

--- a/Octokit.GraphQL/Model/ReactionGroup.cs
+++ b/Octokit.GraphQL/Model/ReactionGroup.cs
@@ -37,7 +37,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ReactingUserConnection Users(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Users(first, after, last, before), Octokit.GraphQL.Model.ReactingUserConnection.Create);
+        public ReactingUserConnection Users(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Users(first, after, last, before), Octokit.GraphQL.Model.ReactingUserConnection.Create);
 
         /// <summary>
         /// Whether or not the authenticated user has left a reaction on the subject.

--- a/Octokit.GraphQL/Model/Ref.cs
+++ b/Octokit.GraphQL/Model/Ref.cs
@@ -27,7 +27,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="headRefName">The head ref name to filter the pull requests by.</param>
         /// <param name="baseRefName">The base ref name to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for pull requests returned from the connection.</param>
-        public PullRequestConnection AssociatedPullRequests(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestState> states = null, IEnumerable<string> labels = null, string headRefName = null, string baseRefName = null, IssueOrder orderBy = null) => this.CreateMethodCall(x => x.AssociatedPullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
+        public PullRequestConnection AssociatedPullRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestState>>? states = null, Arg<IEnumerable<string>>? labels = null, Arg<string>? headRefName = null, Arg<string>? baseRefName = null, Arg<IssueOrder>? orderBy = null) => this.CreateMethodCall(x => x.AssociatedPullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
 
         public string Id { get; }
 

--- a/Octokit.GraphQL/Model/ReferencedEvent.cs
+++ b/Octokit.GraphQL/Model/ReferencedEvent.cs
@@ -40,7 +40,7 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Reference originated in a different repository.
         /// </summary>
-        [Obsolete(@"Use ReferencedEvent.isCrossRepository instead.")]
+        [Obsolete(@"`is_cross_reference` will be renamed. Use ReferencedEvent.isCrossRepository instead. Removal on 2018-07-01 UTC.")]
         public bool IsCrossReference { get; }
 
         /// <summary>

--- a/Octokit.GraphQL/Model/Release.cs
+++ b/Octokit.GraphQL/Model/Release.cs
@@ -60,7 +60,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="name">A list of names to filter the assets by.</param>
-        public ReleaseAssetConnection ReleaseAssets(int? first = null, string after = null, int? last = null, string before = null, string name = null) => this.CreateMethodCall(x => x.ReleaseAssets(first, after, last, before, name), Octokit.GraphQL.Model.ReleaseAssetConnection.Create);
+        public ReleaseAssetConnection ReleaseAssets(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<string>? name = null) => this.CreateMethodCall(x => x.ReleaseAssets(first, after, last, before, name), Octokit.GraphQL.Model.ReleaseAssetConnection.Create);
 
         /// <summary>
         /// The HTTP path for this issue

--- a/Octokit.GraphQL/Model/Repository.cs
+++ b/Octokit.GraphQL/Model/Repository.cs
@@ -22,7 +22,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection AssignableUsers(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.AssignableUsers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection AssignableUsers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.AssignableUsers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// Returns the code of conduct for this repository
@@ -37,7 +37,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="affiliation">Collaborators affiliation level with a repository.</param>
-        public RepositoryCollaboratorConnection Collaborators(int? first = null, string after = null, int? last = null, string before = null, CollaboratorAffiliation? affiliation = null) => this.CreateMethodCall(x => x.Collaborators(first, after, last, before, affiliation), Octokit.GraphQL.Model.RepositoryCollaboratorConnection.Create);
+        public RepositoryCollaboratorConnection Collaborators(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<CollaboratorAffiliation>? affiliation = null) => this.CreateMethodCall(x => x.Collaborators(first, after, last, before, affiliation), Octokit.GraphQL.Model.RepositoryCollaboratorConnection.Create);
 
         /// <summary>
         /// A list of commit comments associated with the repository.
@@ -46,7 +46,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public CommitCommentConnection CommitComments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.CommitComments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
+        public CommitCommentConnection CommitComments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.CommitComments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -71,7 +71,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public DeployKeyConnection DeployKeys(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.DeployKeys(first, after, last, before), Octokit.GraphQL.Model.DeployKeyConnection.Create);
+        public DeployKeyConnection DeployKeys(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.DeployKeys(first, after, last, before), Octokit.GraphQL.Model.DeployKeyConnection.Create);
 
         /// <summary>
         /// Deployments associated with the repository
@@ -81,7 +81,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="environments">Environments to list deployments for</param>
-        public DeploymentConnection Deployments(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<string> environments = null) => this.CreateMethodCall(x => x.Deployments(first, after, last, before, environments), Octokit.GraphQL.Model.DeploymentConnection.Create);
+        public DeploymentConnection Deployments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? environments = null) => this.CreateMethodCall(x => x.Deployments(first, after, last, before, environments), Octokit.GraphQL.Model.DeploymentConnection.Create);
 
         /// <summary>
         /// The description of the repository.
@@ -114,7 +114,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        public RepositoryConnection Forks(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.Forks(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection Forks(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.Forks(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// Indicates if the repository has issues feature enabled.
@@ -162,13 +162,13 @@ namespace Octokit.GraphQL.Model
         /// Returns a single issue from the current repository by number.
         /// </summary>
         /// <param name="number">The number for the issue to be returned.</param>
-        public Issue Issue(int number) => this.CreateMethodCall(x => x.Issue(number), Octokit.GraphQL.Model.Issue.Create);
+        public Issue Issue(Arg<int> number) => this.CreateMethodCall(x => x.Issue(number), Octokit.GraphQL.Model.Issue.Create);
 
         /// <summary>
         /// Returns a single issue-like object from the current repository by number.
         /// </summary>
         /// <param name="number">The number for the issue to be returned.</param>
-        public IssueOrPullRequest IssueOrPullRequest(int number) => this.CreateMethodCall(x => x.IssueOrPullRequest(number), Octokit.GraphQL.Model.IssueOrPullRequest.Create);
+        public IssueOrPullRequest IssueOrPullRequest(Arg<int> number) => this.CreateMethodCall(x => x.IssueOrPullRequest(number), Octokit.GraphQL.Model.IssueOrPullRequest.Create);
 
         /// <summary>
         /// A list of issues that have been opened in the repository.
@@ -180,13 +180,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="labels">A list of label names to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for issues returned from the connection.</param>
         /// <param name="states">A list of states to filter the issues by.</param>
-        public IssueConnection Issues(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<string> labels = null, IssueOrder orderBy = null, IEnumerable<IssueState> states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
+        public IssueConnection Issues(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? labels = null, Arg<IssueOrder>? orderBy = null, Arg<IEnumerable<IssueState>>? states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
 
         /// <summary>
         /// Returns a single label by name
         /// </summary>
         /// <param name="name">Label name</param>
-        public Label Label(string name) => this.CreateMethodCall(x => x.Label(name), Octokit.GraphQL.Model.Label.Create);
+        public Label Label(Arg<string> name) => this.CreateMethodCall(x => x.Label(name), Octokit.GraphQL.Model.Label.Create);
 
         /// <summary>
         /// A list of labels associated with the repository.
@@ -195,7 +195,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public LabelConnection Labels(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
+        public LabelConnection Labels(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Labels(first, after, last, before), Octokit.GraphQL.Model.LabelConnection.Create);
 
         /// <summary>
         /// A list containing a breakdown of the language composition of the repository.
@@ -205,7 +205,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="orderBy">Order for connection</param>
-        public LanguageConnection Languages(int? first = null, string after = null, int? last = null, string before = null, LanguageOrder orderBy = null) => this.CreateMethodCall(x => x.Languages(first, after, last, before, orderBy), Octokit.GraphQL.Model.LanguageConnection.Create);
+        public LanguageConnection Languages(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<LanguageOrder>? orderBy = null) => this.CreateMethodCall(x => x.Languages(first, after, last, before, orderBy), Octokit.GraphQL.Model.LanguageConnection.Create);
 
         /// <summary>
         /// The license associated with the repository
@@ -230,13 +230,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection MentionableUsers(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.MentionableUsers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection MentionableUsers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.MentionableUsers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         /// <summary>
         /// Returns a single milestone from the current repository by number.
         /// </summary>
         /// <param name="number">The number for the milestone to be returned.</param>
-        public Milestone Milestone(int number) => this.CreateMethodCall(x => x.Milestone(number), Octokit.GraphQL.Model.Milestone.Create);
+        public Milestone Milestone(Arg<int> number) => this.CreateMethodCall(x => x.Milestone(number), Octokit.GraphQL.Model.Milestone.Create);
 
         /// <summary>
         /// A list of milestones associated with the repository.
@@ -245,7 +245,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public MilestoneConnection Milestones(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Milestones(first, after, last, before), Octokit.GraphQL.Model.MilestoneConnection.Create);
+        public MilestoneConnection Milestones(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Milestones(first, after, last, before), Octokit.GraphQL.Model.MilestoneConnection.Create);
 
         /// <summary>
         /// The repository's original mirror URL.
@@ -267,7 +267,7 @@ namespace Octokit.GraphQL.Model
         /// </summary>
         /// <param name="oid">The Git object ID</param>
         /// <param name="expression">A Git revision expression suitable for rev-parse</param>
-        public IGitObject Object(string oid = null, string expression = null) => this.CreateMethodCall(x => x.Object(oid, expression), Octokit.GraphQL.Model.Internal.StubIGitObject.Create);
+        public IGitObject Object(Arg<string>? oid = null, Arg<string>? expression = null) => this.CreateMethodCall(x => x.Object(oid, expression), Octokit.GraphQL.Model.Internal.StubIGitObject.Create);
 
         /// <summary>
         /// The User owner of the repository.
@@ -288,7 +288,7 @@ namespace Octokit.GraphQL.Model
         /// Find project by number.
         /// </summary>
         /// <param name="number">The project number to find.</param>
-        public Project Project(int number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
+        public Project Project(Arg<int> number) => this.CreateMethodCall(x => x.Project(number), Octokit.GraphQL.Model.Project.Create);
 
         /// <summary>
         /// A list of projects under the owner.
@@ -300,7 +300,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for projects returned from the connection</param>
         /// <param name="search">Query to search projects by, currently only searching by name.</param>
         /// <param name="states">A list of states to filter the projects by.</param>
-        public ProjectConnection Projects(int? first = null, string after = null, int? last = null, string before = null, ProjectOrder orderBy = null, string search = null, IEnumerable<ProjectState> states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
+        public ProjectConnection Projects(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ProjectOrder>? orderBy = null, Arg<string>? search = null, Arg<IEnumerable<ProjectState>>? states = null) => this.CreateMethodCall(x => x.Projects(first, after, last, before, orderBy, search, states), Octokit.GraphQL.Model.ProjectConnection.Create);
 
         /// <summary>
         /// The HTTP path listing repository's projects
@@ -319,13 +319,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public ProtectedBranchConnection ProtectedBranches(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.ProtectedBranches(first, after, last, before), Octokit.GraphQL.Model.ProtectedBranchConnection.Create);
+        public ProtectedBranchConnection ProtectedBranches(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.ProtectedBranches(first, after, last, before), Octokit.GraphQL.Model.ProtectedBranchConnection.Create);
 
         /// <summary>
         /// Returns a single pull request from the current repository by number.
         /// </summary>
         /// <param name="number">The number for the pull request to be returned.</param>
-        public PullRequest PullRequest(int number) => this.CreateMethodCall(x => x.PullRequest(number), Octokit.GraphQL.Model.PullRequest.Create);
+        public PullRequest PullRequest(Arg<int> number) => this.CreateMethodCall(x => x.PullRequest(number), Octokit.GraphQL.Model.PullRequest.Create);
 
         /// <summary>
         /// A list of pull requests that have been opened in the repository.
@@ -339,7 +339,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="headRefName">The head ref name to filter the pull requests by.</param>
         /// <param name="baseRefName">The base ref name to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for pull requests returned from the connection.</param>
-        public PullRequestConnection PullRequests(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestState> states = null, IEnumerable<string> labels = null, string headRefName = null, string baseRefName = null, IssueOrder orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
+        public PullRequestConnection PullRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestState>>? states = null, Arg<IEnumerable<string>>? labels = null, Arg<string>? headRefName = null, Arg<string>? baseRefName = null, Arg<IssueOrder>? orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
 
         /// <summary>
         /// Identifies when the repository was last pushed to.
@@ -350,7 +350,7 @@ namespace Octokit.GraphQL.Model
         /// Fetch a given ref from the repository
         /// </summary>
         /// <param name="qualifiedName">The ref to retrieve.Fully qualified matches are checked in order (`refs/heads/master`) before falling back onto checks for short name matches (`master`).</param>
-        public Ref Ref(string qualifiedName) => this.CreateMethodCall(x => x.Ref(qualifiedName), Octokit.GraphQL.Model.Ref.Create);
+        public Ref Ref(Arg<string> qualifiedName) => this.CreateMethodCall(x => x.Ref(qualifiedName), Octokit.GraphQL.Model.Ref.Create);
 
         /// <summary>
         /// Fetch a list of refs from the repository
@@ -362,13 +362,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="refPrefix">A ref name prefix like `refs/heads/`, `refs/tags/`, etc.</param>
         /// <param name="direction">DEPRECATED: use orderBy. The ordering direction.</param>
         /// <param name="orderBy">Ordering options for refs returned from the connection.</param>
-        public RefConnection Refs(string refPrefix, int? first = null, string after = null, int? last = null, string before = null, OrderDirection? direction = null, RefOrder orderBy = null) => this.CreateMethodCall(x => x.Refs(refPrefix, first, after, last, before, direction, orderBy), Octokit.GraphQL.Model.RefConnection.Create);
+        public RefConnection Refs(Arg<string> refPrefix, Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<OrderDirection>? direction = null, Arg<RefOrder>? orderBy = null) => this.CreateMethodCall(x => x.Refs(refPrefix, first, after, last, before, direction, orderBy), Octokit.GraphQL.Model.RefConnection.Create);
 
         /// <summary>
         /// Lookup a single release given various criteria.
         /// </summary>
         /// <param name="tagName">The name of the Tag the Release was created from</param>
-        public Release Release(string tagName) => this.CreateMethodCall(x => x.Release(tagName), Octokit.GraphQL.Model.Release.Create);
+        public Release Release(Arg<string> tagName) => this.CreateMethodCall(x => x.Release(tagName), Octokit.GraphQL.Model.Release.Create);
 
         /// <summary>
         /// List of releases which are dependent on this repository.
@@ -378,7 +378,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="orderBy">Order for connection</param>
-        public ReleaseConnection Releases(int? first = null, string after = null, int? last = null, string before = null, ReleaseOrder orderBy = null) => this.CreateMethodCall(x => x.Releases(first, after, last, before, orderBy), Octokit.GraphQL.Model.ReleaseConnection.Create);
+        public ReleaseConnection Releases(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<ReleaseOrder>? orderBy = null) => this.CreateMethodCall(x => x.Releases(first, after, last, before, orderBy), Octokit.GraphQL.Model.ReleaseConnection.Create);
 
         /// <summary>
         /// A list of applied repository-topic associations for this repository.
@@ -387,7 +387,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public RepositoryTopicConnection RepositoryTopics(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.RepositoryTopics(first, after, last, before), Octokit.GraphQL.Model.RepositoryTopicConnection.Create);
+        public RepositoryTopicConnection RepositoryTopics(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.RepositoryTopics(first, after, last, before), Octokit.GraphQL.Model.RepositoryTopicConnection.Create);
 
         /// <summary>
         /// The HTTP path for this repository
@@ -398,7 +398,7 @@ namespace Octokit.GraphQL.Model
         /// A description of the repository, rendered to HTML without any links in it.
         /// </summary>
         /// <param name="limit">How many characters to return.</param>
-        public string ShortDescriptionHTML(int? limit = 200) => null;
+        public string ShortDescriptionHTML(Arg<int>? limit = null) => null;
 
         /// <summary>
         /// The SSH URL to clone this repository
@@ -413,7 +413,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="orderBy">Order for connection</param>
-        public StargazerConnection Stargazers(int? first = null, string after = null, int? last = null, string before = null, StarOrder orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
+        public StargazerConnection Stargazers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<StarOrder>? orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was last updated.
@@ -463,7 +463,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public UserConnection Watchers(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Watchers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
+        public UserConnection Watchers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Watchers(first, after, last, before), Octokit.GraphQL.Model.UserConnection.Create);
 
         internal static Repository Create(Expression expression)
         {

--- a/Octokit.GraphQL/Model/RepositoryInfo.cs
+++ b/Octokit.GraphQL/Model/RepositoryInfo.cs
@@ -122,7 +122,7 @@ namespace Octokit.GraphQL.Model
         /// A description of the repository, rendered to HTML without any links in it.
         /// </summary>
         /// <param name="limit">How many characters to return.</param>
-        string ShortDescriptionHTML(int? limit = 200);
+        string ShortDescriptionHTML(Arg<int>? limit = null);
 
         /// <summary>
         /// Identifies the date and time when the object was last updated.
@@ -193,7 +193,7 @@ namespace Octokit.GraphQL.Model.Internal
 
         public string ResourcePath { get; }
 
-        public string ShortDescriptionHTML(int? limit = 200) => null;
+        public string ShortDescriptionHTML(Arg<int>? limit = null) => null;
 
         [Obsolete(@"General type updated timestamps will eventually be replaced by other field specific timestamps.")]
         public DateTimeOffset? UpdatedAt { get; }

--- a/Octokit.GraphQL/Model/RepositoryInvitationRepository.cs
+++ b/Octokit.GraphQL/Model/RepositoryInvitationRepository.cs
@@ -125,7 +125,7 @@ namespace Octokit.GraphQL.Model
         /// A description of the repository, rendered to HTML without any links in it.
         /// </summary>
         /// <param name="limit">How many characters to return.</param>
-        public string ShortDescriptionHTML(int? limit = 200) => null;
+        public string ShortDescriptionHTML(Arg<int>? limit = null) => null;
 
         /// <summary>
         /// Identifies the date and time when the object was last updated.

--- a/Octokit.GraphQL/Model/RepositoryOwner.cs
+++ b/Octokit.GraphQL/Model/RepositoryOwner.cs
@@ -17,7 +17,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the owner's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        string AvatarUrl(int? size = null);
+        string AvatarUrl(Arg<int>? size = null);
 
         string Id { get; }
 
@@ -37,7 +37,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        RepositoryConnection PinnedRepositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null);
+        RepositoryConnection PinnedRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null);
 
         /// <summary>
         /// A list of repositories that the user owns.
@@ -51,13 +51,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
         /// <param name="isFork">If non-null, filters repositories according to whether they are forks of another repository</param>
-        RepositoryConnection Repositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null, bool? isFork = null);
+        RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null, Arg<bool>? isFork = null);
 
         /// <summary>
         /// Find Repository.
         /// </summary>
         /// <param name="name">Name of Repository to find.</param>
-        Repository Repository(string name);
+        Repository Repository(Arg<string> name);
 
         /// <summary>
         /// The HTTP URL for the owner.
@@ -85,17 +85,17 @@ namespace Octokit.GraphQL.Model.Internal
         {
         }
 
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         public string Id { get; }
 
         public string Login { get; }
 
-        public RepositoryConnection PinnedRepositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection PinnedRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
-        public RepositoryConnection Repositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null, bool? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null, Arg<bool>? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
-        public Repository Repository(string name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
+        public Repository Repository(Arg<string> name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
 
         public string ResourcePath { get; }
 

--- a/Octokit.GraphQL/Model/ReviewRequestRemovedEvent.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestRemovedEvent.cs
@@ -40,7 +40,7 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Identifies the user whose review request was removed.
         /// </summary>
-        [Obsolete(@"Use ReviewRequestRemovedEvent.requestedReviewer instead.")]
+        [Obsolete(@"`subject` will be renamed. Use `ReviewRequestRemovedEvent.requestedReviewer` instead. Removal on 2018-07-01 UTC.")]
         public User Subject => this.CreateProperty(x => x.Subject, Octokit.GraphQL.Model.User.Create);
 
         internal static ReviewRequestRemovedEvent Create(Expression expression)

--- a/Octokit.GraphQL/Model/ReviewRequestedEvent.cs
+++ b/Octokit.GraphQL/Model/ReviewRequestedEvent.cs
@@ -40,7 +40,7 @@ namespace Octokit.GraphQL.Model
         /// <summary>
         /// Identifies the user whose review was requested.
         /// </summary>
-        [Obsolete(@"Use `ReviewRequestedEvent.requestedReviewer` instead.")]
+        [Obsolete(@"`subject` will be renamed. Use `ReviewRequestedEvent.requestedReviewer` instead. Removal on 2018-07-01 UTC.")]
         public User Subject => this.CreateProperty(x => x.Subject, Octokit.GraphQL.Model.User.Create);
 
         internal static ReviewRequestedEvent Create(Expression expression)

--- a/Octokit.GraphQL/Model/Starrable.cs
+++ b/Octokit.GraphQL/Model/Starrable.cs
@@ -23,7 +23,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="orderBy">Order for connection</param>
-        StargazerConnection Stargazers(int? first = null, string after = null, int? last = null, string before = null, StarOrder orderBy = null);
+        StargazerConnection Stargazers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<StarOrder>? orderBy = null);
 
         /// <summary>
         /// Returns a boolean indicating whether the viewing user has starred this starrable.
@@ -48,7 +48,7 @@ namespace Octokit.GraphQL.Model.Internal
 
         public string Id { get; }
 
-        public StargazerConnection Stargazers(int? first = null, string after = null, int? last = null, string before = null, StarOrder orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
+        public StargazerConnection Stargazers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<StarOrder>? orderBy = null) => this.CreateMethodCall(x => x.Stargazers(first, after, last, before, orderBy), Octokit.GraphQL.Model.StargazerConnection.Create);
 
         public bool ViewerHasStarred { get; }
 

--- a/Octokit.GraphQL/Model/Status.cs
+++ b/Octokit.GraphQL/Model/Status.cs
@@ -24,7 +24,7 @@ namespace Octokit.GraphQL.Model
         /// Looks up an individual status context by context name.
         /// </summary>
         /// <param name="name">The context name.</param>
-        public StatusContext Context(string name) => this.CreateMethodCall(x => x.Context(name), Octokit.GraphQL.Model.StatusContext.Create);
+        public StatusContext Context(Arg<string> name) => this.CreateMethodCall(x => x.Context(name), Octokit.GraphQL.Model.StatusContext.Create);
 
         /// <summary>
         /// The individual status contexts for this commit.

--- a/Octokit.GraphQL/Model/Team.cs
+++ b/Octokit.GraphQL/Model/Team.cs
@@ -31,12 +31,6 @@ namespace Octokit.GraphQL.Model
         public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
-        /// A URL pointing to the team's avatar.
-        /// </summary>
-        /// <param name="size">The size in pixels of the resulting square image.</param>
-        public string AvatarUrl(int? size = 400) => null;
-
-        /// <summary>
         /// List of child teams belonging to this team
         /// </summary>
         /// <param name="first">Returns the first _n_ elements from the list.</param>

--- a/Octokit.GraphQL/Model/Team.cs
+++ b/Octokit.GraphQL/Model/Team.cs
@@ -22,7 +22,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public TeamConnection Ancestors(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Ancestors(first, after, last, before), Octokit.GraphQL.Model.TeamConnection.Create);
+        public TeamConnection Ancestors(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Ancestors(first, after, last, before), Octokit.GraphQL.Model.TeamConnection.Create);
+
+        /// <summary>
+        /// A URL pointing to the team's avatar.
+        /// </summary>
+        /// <param name="size">The size in pixels of the resulting square image.</param>
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// List of child teams belonging to this team
@@ -34,7 +40,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Order for connection</param>
         /// <param name="userLogins">User logins to filter by</param>
         /// <param name="immediateOnly">Whether to list immediate child teams or all descendant child teams.</param>
-        public TeamConnection ChildTeams(int? first = null, string after = null, int? last = null, string before = null, TeamOrder orderBy = null, IEnumerable<string> userLogins = null, bool? immediateOnly = true) => this.CreateMethodCall(x => x.ChildTeams(first, after, last, before, orderBy, userLogins, immediateOnly), Octokit.GraphQL.Model.TeamConnection.Create);
+        public TeamConnection ChildTeams(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<TeamOrder>? orderBy = null, Arg<IEnumerable<string>>? userLogins = null, Arg<bool>? immediateOnly = null) => this.CreateMethodCall(x => x.ChildTeams(first, after, last, before, orderBy, userLogins, immediateOnly), Octokit.GraphQL.Model.TeamConnection.Create);
 
         /// <summary>
         /// The slug corresponding to the organization and team.
@@ -70,7 +76,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public OrganizationInvitationConnection Invitations(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Invitations(first, after, last, before), Octokit.GraphQL.Model.OrganizationInvitationConnection.Create);
+        public OrganizationInvitationConnection Invitations(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Invitations(first, after, last, before), Octokit.GraphQL.Model.OrganizationInvitationConnection.Create);
 
         /// <summary>
         /// A list of users who are members of this team.
@@ -82,7 +88,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="query">The search string to look for.</param>
         /// <param name="membership">Filter by membership type</param>
         /// <param name="role">Filter by team member role</param>
-        public TeamMemberConnection Members(int? first = null, string after = null, int? last = null, string before = null, string query = null, TeamMembershipType? membership = TeamMembershipType.All, TeamMemberRole? role = null) => this.CreateMethodCall(x => x.Members(first, after, last, before, query, membership, role), Octokit.GraphQL.Model.TeamMemberConnection.Create);
+        public TeamMemberConnection Members(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<string>? query = null, Arg<TeamMembershipType>? membership = null, Arg<TeamMemberRole>? role = null) => this.CreateMethodCall(x => x.Members(first, after, last, before, query, membership, role), Octokit.GraphQL.Model.TeamMemberConnection.Create);
 
         /// <summary>
         /// The HTTP path for the team' members
@@ -133,7 +139,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="query">The search string to look for.</param>
         /// <param name="orderBy">Order for the connection.</param>
-        public TeamRepositoryConnection Repositories(int? first = null, string after = null, int? last = null, string before = null, string query = null, TeamRepositoryOrder orderBy = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, query, orderBy), Octokit.GraphQL.Model.TeamRepositoryConnection.Create);
+        public TeamRepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<string>? query = null, Arg<TeamRepositoryOrder>? orderBy = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, query, orderBy), Octokit.GraphQL.Model.TeamRepositoryConnection.Create);
 
         /// <summary>
         /// The HTTP path for this team's repositories

--- a/Octokit.GraphQL/Model/User.cs
+++ b/Octokit.GraphQL/Model/User.cs
@@ -19,7 +19,7 @@ namespace Octokit.GraphQL.Model
         /// A URL pointing to the user's public avatar.
         /// </summary>
         /// <param name="size">The size of the resulting square image.</param>
-        public string AvatarUrl(int? size = null) => null;
+        public string AvatarUrl(Arg<int>? size = null) => null;
 
         /// <summary>
         /// The user's public profile bio.
@@ -38,7 +38,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public CommitCommentConnection CommitComments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.CommitComments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
+        public CommitCommentConnection CommitComments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.CommitComments(first, after, last, before), Octokit.GraphQL.Model.CommitCommentConnection.Create);
 
         /// <summary>
         /// The user's public profile company.
@@ -61,7 +61,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        public RepositoryConnection ContributedRepositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.ContributedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection ContributedRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.ContributedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was created.
@@ -86,7 +86,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public FollowerConnection Followers(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Followers(first, after, last, before), Octokit.GraphQL.Model.FollowerConnection.Create);
+        public FollowerConnection Followers(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Followers(first, after, last, before), Octokit.GraphQL.Model.FollowerConnection.Create);
 
         /// <summary>
         /// A list of users the given user is following.
@@ -95,13 +95,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public FollowingConnection Following(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Following(first, after, last, before), Octokit.GraphQL.Model.FollowingConnection.Create);
+        public FollowingConnection Following(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Following(first, after, last, before), Octokit.GraphQL.Model.FollowingConnection.Create);
 
         /// <summary>
         /// Find gist by repo name.
         /// </summary>
         /// <param name="name">The gist name to find.</param>
-        public Gist Gist(string name) => this.CreateMethodCall(x => x.Gist(name), Octokit.GraphQL.Model.Gist.Create);
+        public Gist Gist(Arg<string> name) => this.CreateMethodCall(x => x.Gist(name), Octokit.GraphQL.Model.Gist.Create);
 
         /// <summary>
         /// A list of gist comments made by this user.
@@ -110,7 +110,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public GistCommentConnection GistComments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.GistComments(first, after, last, before), Octokit.GraphQL.Model.GistCommentConnection.Create);
+        public GistCommentConnection GistComments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.GistComments(first, after, last, before), Octokit.GraphQL.Model.GistCommentConnection.Create);
 
         /// <summary>
         /// A list of the Gists the user has created.
@@ -121,7 +121,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="privacy">Filters Gists according to privacy.</param>
         /// <param name="orderBy">Ordering options for gists returned from the connection</param>
-        public GistConnection Gists(int? first = null, string after = null, int? last = null, string before = null, GistPrivacy? privacy = null, GistOrder orderBy = null) => this.CreateMethodCall(x => x.Gists(first, after, last, before, privacy, orderBy), Octokit.GraphQL.Model.GistConnection.Create);
+        public GistConnection Gists(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<GistPrivacy>? privacy = null, Arg<GistOrder>? orderBy = null) => this.CreateMethodCall(x => x.Gists(first, after, last, before, privacy, orderBy), Octokit.GraphQL.Model.GistConnection.Create);
 
         public string Id { get; }
 
@@ -167,7 +167,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public IssueCommentConnection IssueComments(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.IssueComments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
+        public IssueCommentConnection IssueComments(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.IssueComments(first, after, last, before), Octokit.GraphQL.Model.IssueCommentConnection.Create);
 
         /// <summary>
         /// A list of issues assocated with this user.
@@ -179,7 +179,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="labels">A list of label names to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for issues returned from the connection.</param>
         /// <param name="states">A list of states to filter the issues by.</param>
-        public IssueConnection Issues(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<string> labels = null, IssueOrder orderBy = null, IEnumerable<IssueState> states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
+        public IssueConnection Issues(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<string>>? labels = null, Arg<IssueOrder>? orderBy = null, Arg<IEnumerable<IssueState>>? states = null) => this.CreateMethodCall(x => x.Issues(first, after, last, before, labels, orderBy, states), Octokit.GraphQL.Model.IssueConnection.Create);
 
         /// <summary>
         /// The user's public profile location.
@@ -200,7 +200,7 @@ namespace Octokit.GraphQL.Model
         /// Find an organization by its login that the user belongs to.
         /// </summary>
         /// <param name="login">The login of the organization to find.</param>
-        public Organization Organization(string login) => this.CreateMethodCall(x => x.Organization(login), Octokit.GraphQL.Model.Organization.Create);
+        public Organization Organization(Arg<string> login) => this.CreateMethodCall(x => x.Organization(login), Octokit.GraphQL.Model.Organization.Create);
 
         /// <summary>
         /// A list of organizations the user belongs to.
@@ -209,7 +209,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public OrganizationConnection Organizations(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Organizations(first, after, last, before), Octokit.GraphQL.Model.OrganizationConnection.Create);
+        public OrganizationConnection Organizations(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Organizations(first, after, last, before), Octokit.GraphQL.Model.OrganizationConnection.Create);
 
         /// <summary>
         /// A list of repositories this user has pinned to their profile
@@ -222,7 +222,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        public RepositoryConnection PinnedRepositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection PinnedRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.PinnedRepositories(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// A list of public keys associated with this user.
@@ -231,7 +231,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="after">Returns the elements in the list that come after the specified global ID.</param>
         /// <param name="last">Returns the last _n_ elements from the list.</param>
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
-        public PublicKeyConnection PublicKeys(int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.PublicKeys(first, after, last, before), Octokit.GraphQL.Model.PublicKeyConnection.Create);
+        public PublicKeyConnection PublicKeys(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.PublicKeys(first, after, last, before), Octokit.GraphQL.Model.PublicKeyConnection.Create);
 
         /// <summary>
         /// A list of pull requests assocated with this user.
@@ -245,7 +245,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="headRefName">The head ref name to filter the pull requests by.</param>
         /// <param name="baseRefName">The base ref name to filter the pull requests by.</param>
         /// <param name="orderBy">Ordering options for pull requests returned from the connection.</param>
-        public PullRequestConnection PullRequests(int? first = null, string after = null, int? last = null, string before = null, IEnumerable<PullRequestState> states = null, IEnumerable<string> labels = null, string headRefName = null, string baseRefName = null, IssueOrder orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
+        public PullRequestConnection PullRequests(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<IEnumerable<PullRequestState>>? states = null, Arg<IEnumerable<string>>? labels = null, Arg<string>? headRefName = null, Arg<string>? baseRefName = null, Arg<IssueOrder>? orderBy = null) => this.CreateMethodCall(x => x.PullRequests(first, after, last, before, states, labels, headRefName, baseRefName, orderBy), Octokit.GraphQL.Model.PullRequestConnection.Create);
 
         /// <summary>
         /// A list of repositories that the user owns.
@@ -259,7 +259,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
         /// <param name="isFork">If non-null, filters repositories according to whether they are forks of another repository</param>
-        public RepositoryConnection Repositories(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null, bool? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection Repositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null, Arg<bool>? isFork = null) => this.CreateMethodCall(x => x.Repositories(first, after, last, before, privacy, orderBy, affiliations, isLocked, isFork), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// A list of repositories that the user recently contributed to.
@@ -273,13 +273,13 @@ namespace Octokit.GraphQL.Model
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
         /// <param name="includeUserRepositories">If true, include user repositories</param>
         /// <param name="contributionTypes">If non-null, include only the specified types of contributions. The GitHub.com UI uses [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]</param>
-        public RepositoryConnection RepositoriesContributedTo(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, bool? isLocked = null, bool? includeUserRepositories = null, IEnumerable<RepositoryContributionType?> contributionTypes = null) => this.CreateMethodCall(x => x.RepositoriesContributedTo(first, after, last, before, privacy, orderBy, isLocked, includeUserRepositories, contributionTypes), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection RepositoriesContributedTo(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<bool>? isLocked = null, Arg<bool>? includeUserRepositories = null, Arg<IEnumerable<RepositoryContributionType?>>? contributionTypes = null) => this.CreateMethodCall(x => x.RepositoriesContributedTo(first, after, last, before, privacy, orderBy, isLocked, includeUserRepositories, contributionTypes), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// Find Repository.
         /// </summary>
         /// <param name="name">Name of Repository to find.</param>
-        public Repository Repository(string name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
+        public Repository Repository(Arg<string> name) => this.CreateMethodCall(x => x.Repository(name), Octokit.GraphQL.Model.Repository.Create);
 
         /// <summary>
         /// The HTTP path for this user
@@ -295,7 +295,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="ownedByViewer">Filters starred repositories to only return repositories owned by the viewer.</param>
         /// <param name="orderBy">Order for connection</param>
-        public StarredRepositoryConnection StarredRepositories(int? first = null, string after = null, int? last = null, string before = null, bool? ownedByViewer = null, StarOrder orderBy = null) => this.CreateMethodCall(x => x.StarredRepositories(first, after, last, before, ownedByViewer, orderBy), Octokit.GraphQL.Model.StarredRepositoryConnection.Create);
+        public StarredRepositoryConnection StarredRepositories(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<bool>? ownedByViewer = null, Arg<StarOrder>? orderBy = null) => this.CreateMethodCall(x => x.StarredRepositories(first, after, last, before, ownedByViewer, orderBy), Octokit.GraphQL.Model.StarredRepositoryConnection.Create);
 
         /// <summary>
         /// Identifies the date and time when the object was last updated.
@@ -329,7 +329,7 @@ namespace Octokit.GraphQL.Model
         /// <param name="orderBy">Ordering options for repositories returned from the connection</param>
         /// <param name="affiliations">Affiliation options for repositories returned from the connection</param>
         /// <param name="isLocked">If non-null, filters repositories according to whether they have been locked</param>
-        public RepositoryConnection Watching(int? first = null, string after = null, int? last = null, string before = null, RepositoryPrivacy? privacy = null, RepositoryOrder orderBy = null, IEnumerable<RepositoryAffiliation?> affiliations = null, bool? isLocked = null) => this.CreateMethodCall(x => x.Watching(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
+        public RepositoryConnection Watching(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<RepositoryPrivacy>? privacy = null, Arg<RepositoryOrder>? orderBy = null, Arg<IEnumerable<RepositoryAffiliation?>>? affiliations = null, Arg<bool>? isLocked = null) => this.CreateMethodCall(x => x.Watching(first, after, last, before, privacy, orderBy, affiliations, isLocked), Octokit.GraphQL.Model.RepositoryConnection.Create);
 
         /// <summary>
         /// A URL pointing to the user's public website/blog.

--- a/Octokit.GraphQL/Model/UserContentEditConnection.cs
+++ b/Octokit.GraphQL/Model/UserContentEditConnection.cs
@@ -1,0 +1,43 @@
+namespace Octokit.GraphQL.Model
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using Octokit.GraphQL.Core;
+    using Octokit.GraphQL.Core.Builders;
+
+    /// <summary>
+    /// A list of edits to content.
+    /// </summary>
+    public class UserContentEditConnection : QueryableValue<UserContentEditConnection>
+    {
+        public UserContentEditConnection(Expression expression) : base(expression)
+        {
+        }
+
+        /// <summary>
+        /// A list of edges.
+        /// </summary>
+        public IQueryableList<UserContentEditEdge> Edges => this.CreateProperty(x => x.Edges);
+
+        /// <summary>
+        /// A list of nodes.
+        /// </summary>
+        public IQueryableList<UserContentEdit> Nodes => this.CreateProperty(x => x.Nodes);
+
+        /// <summary>
+        /// Information to aid in pagination.
+        /// </summary>
+        public PageInfo PageInfo => this.CreateProperty(x => x.PageInfo, Octokit.GraphQL.Model.PageInfo.Create);
+
+        /// <summary>
+        /// Identifies the total count of items in the connection.
+        /// </summary>
+        public int TotalCount { get; }
+
+        internal static UserContentEditConnection Create(Expression expression)
+        {
+            return new UserContentEditConnection(expression);
+        }
+    }
+}

--- a/Octokit.GraphQL/Mutation.cs
+++ b/Octokit.GraphQL/Mutation.cs
@@ -23,152 +23,152 @@ namespace Octokit.GraphQL
         /// <summary>
         /// Applies a suggested topic to the repository.
         /// </summary>
-        public AcceptTopicSuggestionPayload AcceptTopicSuggestion(AcceptTopicSuggestionInput input) => this.CreateMethodCall(x => x.AcceptTopicSuggestion(input), Octokit.GraphQL.Model.AcceptTopicSuggestionPayload.Create);
+        public AcceptTopicSuggestionPayload AcceptTopicSuggestion(Arg<AcceptTopicSuggestionInput> input) => this.CreateMethodCall(x => x.AcceptTopicSuggestion(input), Octokit.GraphQL.Model.AcceptTopicSuggestionPayload.Create);
 
         /// <summary>
         /// Adds a comment to an Issue or Pull Request.
         /// </summary>
-        public AddCommentPayload AddComment(AddCommentInput input) => this.CreateMethodCall(x => x.AddComment(input), Octokit.GraphQL.Model.AddCommentPayload.Create);
+        public AddCommentPayload AddComment(Arg<AddCommentInput> input) => this.CreateMethodCall(x => x.AddComment(input), Octokit.GraphQL.Model.AddCommentPayload.Create);
 
         /// <summary>
         /// Adds a card to a ProjectColumn. Either `contentId` or `note` must be provided but **not** both.
         /// </summary>
-        public AddProjectCardPayload AddProjectCard(AddProjectCardInput input) => this.CreateMethodCall(x => x.AddProjectCard(input), Octokit.GraphQL.Model.AddProjectCardPayload.Create);
+        public AddProjectCardPayload AddProjectCard(Arg<AddProjectCardInput> input) => this.CreateMethodCall(x => x.AddProjectCard(input), Octokit.GraphQL.Model.AddProjectCardPayload.Create);
 
         /// <summary>
         /// Adds a column to a Project.
         /// </summary>
-        public AddProjectColumnPayload AddProjectColumn(AddProjectColumnInput input) => this.CreateMethodCall(x => x.AddProjectColumn(input), Octokit.GraphQL.Model.AddProjectColumnPayload.Create);
+        public AddProjectColumnPayload AddProjectColumn(Arg<AddProjectColumnInput> input) => this.CreateMethodCall(x => x.AddProjectColumn(input), Octokit.GraphQL.Model.AddProjectColumnPayload.Create);
 
         /// <summary>
         /// Adds a review to a Pull Request.
         /// </summary>
-        public AddPullRequestReviewPayload AddPullRequestReview(AddPullRequestReviewInput input) => this.CreateMethodCall(x => x.AddPullRequestReview(input), Octokit.GraphQL.Model.AddPullRequestReviewPayload.Create);
+        public AddPullRequestReviewPayload AddPullRequestReview(Arg<AddPullRequestReviewInput> input) => this.CreateMethodCall(x => x.AddPullRequestReview(input), Octokit.GraphQL.Model.AddPullRequestReviewPayload.Create);
 
         /// <summary>
         /// Adds a comment to a review.
         /// </summary>
-        public AddPullRequestReviewCommentPayload AddPullRequestReviewComment(AddPullRequestReviewCommentInput input) => this.CreateMethodCall(x => x.AddPullRequestReviewComment(input), Octokit.GraphQL.Model.AddPullRequestReviewCommentPayload.Create);
+        public AddPullRequestReviewCommentPayload AddPullRequestReviewComment(Arg<AddPullRequestReviewCommentInput> input) => this.CreateMethodCall(x => x.AddPullRequestReviewComment(input), Octokit.GraphQL.Model.AddPullRequestReviewCommentPayload.Create);
 
         /// <summary>
         /// Adds a reaction to a subject.
         /// </summary>
-        public AddReactionPayload AddReaction(AddReactionInput input) => this.CreateMethodCall(x => x.AddReaction(input), Octokit.GraphQL.Model.AddReactionPayload.Create);
+        public AddReactionPayload AddReaction(Arg<AddReactionInput> input) => this.CreateMethodCall(x => x.AddReaction(input), Octokit.GraphQL.Model.AddReactionPayload.Create);
 
         /// <summary>
         /// Adds a star to a Starrable.
         /// </summary>
-        public AddStarPayload AddStar(AddStarInput input) => this.CreateMethodCall(x => x.AddStar(input), Octokit.GraphQL.Model.AddStarPayload.Create);
+        public AddStarPayload AddStar(Arg<AddStarInput> input) => this.CreateMethodCall(x => x.AddStar(input), Octokit.GraphQL.Model.AddStarPayload.Create);
 
         /// <summary>
         /// Creates a new project.
         /// </summary>
-        public CreateProjectPayload CreateProject(CreateProjectInput input) => this.CreateMethodCall(x => x.CreateProject(input), Octokit.GraphQL.Model.CreateProjectPayload.Create);
+        public CreateProjectPayload CreateProject(Arg<CreateProjectInput> input) => this.CreateMethodCall(x => x.CreateProject(input), Octokit.GraphQL.Model.CreateProjectPayload.Create);
 
         /// <summary>
         /// Rejects a suggested topic for the repository.
         /// </summary>
-        public DeclineTopicSuggestionPayload DeclineTopicSuggestion(DeclineTopicSuggestionInput input) => this.CreateMethodCall(x => x.DeclineTopicSuggestion(input), Octokit.GraphQL.Model.DeclineTopicSuggestionPayload.Create);
+        public DeclineTopicSuggestionPayload DeclineTopicSuggestion(Arg<DeclineTopicSuggestionInput> input) => this.CreateMethodCall(x => x.DeclineTopicSuggestion(input), Octokit.GraphQL.Model.DeclineTopicSuggestionPayload.Create);
 
         /// <summary>
         /// Deletes a project.
         /// </summary>
-        public DeleteProjectPayload DeleteProject(DeleteProjectInput input) => this.CreateMethodCall(x => x.DeleteProject(input), Octokit.GraphQL.Model.DeleteProjectPayload.Create);
+        public DeleteProjectPayload DeleteProject(Arg<DeleteProjectInput> input) => this.CreateMethodCall(x => x.DeleteProject(input), Octokit.GraphQL.Model.DeleteProjectPayload.Create);
 
         /// <summary>
         /// Deletes a project card.
         /// </summary>
-        public DeleteProjectCardPayload DeleteProjectCard(DeleteProjectCardInput input) => this.CreateMethodCall(x => x.DeleteProjectCard(input), Octokit.GraphQL.Model.DeleteProjectCardPayload.Create);
+        public DeleteProjectCardPayload DeleteProjectCard(Arg<DeleteProjectCardInput> input) => this.CreateMethodCall(x => x.DeleteProjectCard(input), Octokit.GraphQL.Model.DeleteProjectCardPayload.Create);
 
         /// <summary>
         /// Deletes a project column.
         /// </summary>
-        public DeleteProjectColumnPayload DeleteProjectColumn(DeleteProjectColumnInput input) => this.CreateMethodCall(x => x.DeleteProjectColumn(input), Octokit.GraphQL.Model.DeleteProjectColumnPayload.Create);
+        public DeleteProjectColumnPayload DeleteProjectColumn(Arg<DeleteProjectColumnInput> input) => this.CreateMethodCall(x => x.DeleteProjectColumn(input), Octokit.GraphQL.Model.DeleteProjectColumnPayload.Create);
 
         /// <summary>
         /// Deletes a pull request review.
         /// </summary>
-        public DeletePullRequestReviewPayload DeletePullRequestReview(DeletePullRequestReviewInput input) => this.CreateMethodCall(x => x.DeletePullRequestReview(input), Octokit.GraphQL.Model.DeletePullRequestReviewPayload.Create);
+        public DeletePullRequestReviewPayload DeletePullRequestReview(Arg<DeletePullRequestReviewInput> input) => this.CreateMethodCall(x => x.DeletePullRequestReview(input), Octokit.GraphQL.Model.DeletePullRequestReviewPayload.Create);
 
         /// <summary>
         /// Dismisses an approved or rejected pull request review.
         /// </summary>
-        public DismissPullRequestReviewPayload DismissPullRequestReview(DismissPullRequestReviewInput input) => this.CreateMethodCall(x => x.DismissPullRequestReview(input), Octokit.GraphQL.Model.DismissPullRequestReviewPayload.Create);
+        public DismissPullRequestReviewPayload DismissPullRequestReview(Arg<DismissPullRequestReviewInput> input) => this.CreateMethodCall(x => x.DismissPullRequestReview(input), Octokit.GraphQL.Model.DismissPullRequestReviewPayload.Create);
 
         /// <summary>
         /// Lock a lockable object
         /// </summary>
-        public LockLockablePayload LockLockable(LockLockableInput input) => this.CreateMethodCall(x => x.LockLockable(input), Octokit.GraphQL.Model.LockLockablePayload.Create);
+        public LockLockablePayload LockLockable(Arg<LockLockableInput> input) => this.CreateMethodCall(x => x.LockLockable(input), Octokit.GraphQL.Model.LockLockablePayload.Create);
 
         /// <summary>
         /// Moves a project card to another place.
         /// </summary>
-        public MoveProjectCardPayload MoveProjectCard(MoveProjectCardInput input) => this.CreateMethodCall(x => x.MoveProjectCard(input), Octokit.GraphQL.Model.MoveProjectCardPayload.Create);
+        public MoveProjectCardPayload MoveProjectCard(Arg<MoveProjectCardInput> input) => this.CreateMethodCall(x => x.MoveProjectCard(input), Octokit.GraphQL.Model.MoveProjectCardPayload.Create);
 
         /// <summary>
         /// Moves a project column to another place.
         /// </summary>
-        public MoveProjectColumnPayload MoveProjectColumn(MoveProjectColumnInput input) => this.CreateMethodCall(x => x.MoveProjectColumn(input), Octokit.GraphQL.Model.MoveProjectColumnPayload.Create);
+        public MoveProjectColumnPayload MoveProjectColumn(Arg<MoveProjectColumnInput> input) => this.CreateMethodCall(x => x.MoveProjectColumn(input), Octokit.GraphQL.Model.MoveProjectColumnPayload.Create);
 
         /// <summary>
         /// Removes outside collaborator from all repositories in an organization.
         /// </summary>
-        public RemoveOutsideCollaboratorPayload RemoveOutsideCollaborator(RemoveOutsideCollaboratorInput input) => this.CreateMethodCall(x => x.RemoveOutsideCollaborator(input), Octokit.GraphQL.Model.RemoveOutsideCollaboratorPayload.Create);
+        public RemoveOutsideCollaboratorPayload RemoveOutsideCollaborator(Arg<RemoveOutsideCollaboratorInput> input) => this.CreateMethodCall(x => x.RemoveOutsideCollaborator(input), Octokit.GraphQL.Model.RemoveOutsideCollaboratorPayload.Create);
 
         /// <summary>
         /// Removes a reaction from a subject.
         /// </summary>
-        public RemoveReactionPayload RemoveReaction(RemoveReactionInput input) => this.CreateMethodCall(x => x.RemoveReaction(input), Octokit.GraphQL.Model.RemoveReactionPayload.Create);
+        public RemoveReactionPayload RemoveReaction(Arg<RemoveReactionInput> input) => this.CreateMethodCall(x => x.RemoveReaction(input), Octokit.GraphQL.Model.RemoveReactionPayload.Create);
 
         /// <summary>
         /// Removes a star from a Starrable.
         /// </summary>
-        public RemoveStarPayload RemoveStar(RemoveStarInput input) => this.CreateMethodCall(x => x.RemoveStar(input), Octokit.GraphQL.Model.RemoveStarPayload.Create);
+        public RemoveStarPayload RemoveStar(Arg<RemoveStarInput> input) => this.CreateMethodCall(x => x.RemoveStar(input), Octokit.GraphQL.Model.RemoveStarPayload.Create);
 
         /// <summary>
         /// Set review requests on a pull request.
         /// </summary>
-        public RequestReviewsPayload RequestReviews(RequestReviewsInput input) => this.CreateMethodCall(x => x.RequestReviews(input), Octokit.GraphQL.Model.RequestReviewsPayload.Create);
+        public RequestReviewsPayload RequestReviews(Arg<RequestReviewsInput> input) => this.CreateMethodCall(x => x.RequestReviews(input), Octokit.GraphQL.Model.RequestReviewsPayload.Create);
 
         /// <summary>
         /// Submits a pending pull request review.
         /// </summary>
-        public SubmitPullRequestReviewPayload SubmitPullRequestReview(SubmitPullRequestReviewInput input) => this.CreateMethodCall(x => x.SubmitPullRequestReview(input), Octokit.GraphQL.Model.SubmitPullRequestReviewPayload.Create);
+        public SubmitPullRequestReviewPayload SubmitPullRequestReview(Arg<SubmitPullRequestReviewInput> input) => this.CreateMethodCall(x => x.SubmitPullRequestReview(input), Octokit.GraphQL.Model.SubmitPullRequestReviewPayload.Create);
 
         /// <summary>
         /// Updates an existing project.
         /// </summary>
-        public UpdateProjectPayload UpdateProject(UpdateProjectInput input) => this.CreateMethodCall(x => x.UpdateProject(input), Octokit.GraphQL.Model.UpdateProjectPayload.Create);
+        public UpdateProjectPayload UpdateProject(Arg<UpdateProjectInput> input) => this.CreateMethodCall(x => x.UpdateProject(input), Octokit.GraphQL.Model.UpdateProjectPayload.Create);
 
         /// <summary>
         /// Updates an existing project card.
         /// </summary>
-        public UpdateProjectCardPayload UpdateProjectCard(UpdateProjectCardInput input) => this.CreateMethodCall(x => x.UpdateProjectCard(input), Octokit.GraphQL.Model.UpdateProjectCardPayload.Create);
+        public UpdateProjectCardPayload UpdateProjectCard(Arg<UpdateProjectCardInput> input) => this.CreateMethodCall(x => x.UpdateProjectCard(input), Octokit.GraphQL.Model.UpdateProjectCardPayload.Create);
 
         /// <summary>
         /// Updates an existing project column.
         /// </summary>
-        public UpdateProjectColumnPayload UpdateProjectColumn(UpdateProjectColumnInput input) => this.CreateMethodCall(x => x.UpdateProjectColumn(input), Octokit.GraphQL.Model.UpdateProjectColumnPayload.Create);
+        public UpdateProjectColumnPayload UpdateProjectColumn(Arg<UpdateProjectColumnInput> input) => this.CreateMethodCall(x => x.UpdateProjectColumn(input), Octokit.GraphQL.Model.UpdateProjectColumnPayload.Create);
 
         /// <summary>
         /// Updates the body of a pull request review.
         /// </summary>
-        public UpdatePullRequestReviewPayload UpdatePullRequestReview(UpdatePullRequestReviewInput input) => this.CreateMethodCall(x => x.UpdatePullRequestReview(input), Octokit.GraphQL.Model.UpdatePullRequestReviewPayload.Create);
+        public UpdatePullRequestReviewPayload UpdatePullRequestReview(Arg<UpdatePullRequestReviewInput> input) => this.CreateMethodCall(x => x.UpdatePullRequestReview(input), Octokit.GraphQL.Model.UpdatePullRequestReviewPayload.Create);
 
         /// <summary>
         /// Updates a pull request review comment.
         /// </summary>
-        public UpdatePullRequestReviewCommentPayload UpdatePullRequestReviewComment(UpdatePullRequestReviewCommentInput input) => this.CreateMethodCall(x => x.UpdatePullRequestReviewComment(input), Octokit.GraphQL.Model.UpdatePullRequestReviewCommentPayload.Create);
+        public UpdatePullRequestReviewCommentPayload UpdatePullRequestReviewComment(Arg<UpdatePullRequestReviewCommentInput> input) => this.CreateMethodCall(x => x.UpdatePullRequestReviewComment(input), Octokit.GraphQL.Model.UpdatePullRequestReviewCommentPayload.Create);
 
         /// <summary>
         /// Updates viewers repository subscription state.
         /// </summary>
-        public UpdateSubscriptionPayload UpdateSubscription(UpdateSubscriptionInput input) => this.CreateMethodCall(x => x.UpdateSubscription(input), Octokit.GraphQL.Model.UpdateSubscriptionPayload.Create);
+        public UpdateSubscriptionPayload UpdateSubscription(Arg<UpdateSubscriptionInput> input) => this.CreateMethodCall(x => x.UpdateSubscription(input), Octokit.GraphQL.Model.UpdateSubscriptionPayload.Create);
 
         /// <summary>
         /// Replaces the repository's topics with the given topics.
         /// </summary>
-        public UpdateTopicsPayload UpdateTopics(UpdateTopicsInput input) => this.CreateMethodCall(x => x.UpdateTopics(input), Octokit.GraphQL.Model.UpdateTopicsPayload.Create);
+        public UpdateTopicsPayload UpdateTopics(Arg<UpdateTopicsInput> input) => this.CreateMethodCall(x => x.UpdateTopics(input), Octokit.GraphQL.Model.UpdateTopicsPayload.Create);
 
         internal static Mutation Create(Expression expression)
         {

--- a/Octokit.GraphQL/Query.cs
+++ b/Octokit.GraphQL/Query.cs
@@ -24,7 +24,7 @@ namespace Octokit.GraphQL
         /// Look up a code of conduct by its key
         /// </summary>
         /// <param name="key">The code of conduct's key</param>
-        public CodeOfConduct CodeOfConduct(string key) => this.CreateMethodCall(x => x.CodeOfConduct(key), Octokit.GraphQL.Model.CodeOfConduct.Create);
+        public CodeOfConduct CodeOfConduct(Arg<string> key) => this.CreateMethodCall(x => x.CodeOfConduct(key), Octokit.GraphQL.Model.CodeOfConduct.Create);
 
         /// <summary>
         /// Look up a code of conduct by its key
@@ -35,7 +35,7 @@ namespace Octokit.GraphQL
         /// Look up an open source license by its key
         /// </summary>
         /// <param name="key">The license's downcased SPDX ID</param>
-        public License License(string key) => this.CreateMethodCall(x => x.License(key), Octokit.GraphQL.Model.License.Create);
+        public License License(Arg<string> key) => this.CreateMethodCall(x => x.License(key), Octokit.GraphQL.Model.License.Create);
 
         /// <summary>
         /// Return a list of known open source licenses
@@ -46,19 +46,19 @@ namespace Octokit.GraphQL
         /// Get alphabetically sorted list of Marketplace categories
         /// </summary>
         /// <param name="excludeEmpty">Exclude categories with no listings.</param>
-        public IQueryableList<MarketplaceCategory> MarketplaceCategories(bool? excludeEmpty = null) => this.CreateMethodCall(x => x.MarketplaceCategories(excludeEmpty));
+        public IQueryableList<MarketplaceCategory> MarketplaceCategories(Arg<bool>? excludeEmpty = null) => this.CreateMethodCall(x => x.MarketplaceCategories(excludeEmpty));
 
         /// <summary>
         /// Look up a Marketplace category by its slug.
         /// </summary>
         /// <param name="slug">The URL slug of the category.</param>
-        public MarketplaceCategory MarketplaceCategory(string slug) => this.CreateMethodCall(x => x.MarketplaceCategory(slug), Octokit.GraphQL.Model.MarketplaceCategory.Create);
+        public MarketplaceCategory MarketplaceCategory(Arg<string> slug) => this.CreateMethodCall(x => x.MarketplaceCategory(slug), Octokit.GraphQL.Model.MarketplaceCategory.Create);
 
         /// <summary>
         /// Look up a single Marketplace listing
         /// </summary>
         /// <param name="slug">Select the listing that matches this slug. It's the short name of the listing used in its URL.</param>
-        public MarketplaceListing MarketplaceListing(string slug) => this.CreateMethodCall(x => x.MarketplaceListing(slug), Octokit.GraphQL.Model.MarketplaceListing.Create);
+        public MarketplaceListing MarketplaceListing(Arg<string> slug) => this.CreateMethodCall(x => x.MarketplaceListing(slug), Octokit.GraphQL.Model.MarketplaceListing.Create);
 
         /// <summary>
         /// Look up Marketplace listings
@@ -75,7 +75,7 @@ namespace Octokit.GraphQL
         /// <param name="slugs">Select the listings with these slugs, if they are visible to the viewer.</param>
         /// <param name="primaryCategoryOnly">Select only listings where the primary category matches the given category slug.</param>
         /// <param name="withFreeTrialsOnly">Select only listings that offer a free trial.</param>
-        public MarketplaceListingConnection MarketplaceListings(int? first = null, string after = null, int? last = null, string before = null, string categorySlug = null, bool? viewerCanAdmin = null, string adminId = null, string organizationId = null, bool? allStates = null, IEnumerable<string> slugs = null, bool? primaryCategoryOnly = false, bool? withFreeTrialsOnly = false) => this.CreateMethodCall(x => x.MarketplaceListings(first, after, last, before, categorySlug, viewerCanAdmin, adminId, organizationId, allStates, slugs, primaryCategoryOnly, withFreeTrialsOnly), Octokit.GraphQL.Model.MarketplaceListingConnection.Create);
+        public MarketplaceListingConnection MarketplaceListings(Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null, Arg<string>? categorySlug = null, Arg<bool>? viewerCanAdmin = null, Arg<string>? adminId = null, Arg<string>? organizationId = null, Arg<bool>? allStates = null, Arg<IEnumerable<string>>? slugs = null, Arg<bool>? primaryCategoryOnly = null, Arg<bool>? withFreeTrialsOnly = null) => this.CreateMethodCall(x => x.MarketplaceListings(first, after, last, before, categorySlug, viewerCanAdmin, adminId, organizationId, allStates, slugs, primaryCategoryOnly, withFreeTrialsOnly), Octokit.GraphQL.Model.MarketplaceListingConnection.Create);
 
         /// <summary>
         /// Return information about the GitHub instance
@@ -86,25 +86,25 @@ namespace Octokit.GraphQL
         /// Fetches an object given its ID.
         /// </summary>
         /// <param name="id">ID of the object.</param>
-        public INode Node(string id) => this.CreateMethodCall(x => x.Node(id), Octokit.GraphQL.Model.Internal.StubINode.Create);
+        public INode Node(Arg<string> id) => this.CreateMethodCall(x => x.Node(id), Octokit.GraphQL.Model.Internal.StubINode.Create);
 
         /// <summary>
         /// Lookup nodes by a list of IDs.
         /// </summary>
         /// <param name="ids">The list of node IDs.</param>
-        public IQueryableList<INode> Nodes(IEnumerable<string> ids) => this.CreateMethodCall(x => x.Nodes(ids));
+        public IQueryableList<INode> Nodes(Arg<IEnumerable<string>> ids) => this.CreateMethodCall(x => x.Nodes(ids));
 
         /// <summary>
         /// Lookup a organization by login.
         /// </summary>
         /// <param name="login">The organization's login.</param>
-        public Organization Organization(string login) => this.CreateMethodCall(x => x.Organization(login), Octokit.GraphQL.Model.Organization.Create);
+        public Organization Organization(Arg<string> login) => this.CreateMethodCall(x => x.Organization(login), Octokit.GraphQL.Model.Organization.Create);
 
         /// <summary>
         /// The client's rate limit information.
         /// </summary>
         /// <param name="dryRun">If true, calculate the cost for the query without evaluating it</param>
-        public RateLimit RateLimit(bool? dryRun = false) => this.CreateMethodCall(x => x.RateLimit(dryRun), Octokit.GraphQL.Model.RateLimit.Create);
+        public RateLimit RateLimit(Arg<bool>? dryRun = null) => this.CreateMethodCall(x => x.RateLimit(dryRun), Octokit.GraphQL.Model.RateLimit.Create);
 
         /// <summary>
         /// Hack to workaround https://github.com/facebook/relay/issues/112 re-exposing the root query object
@@ -116,19 +116,19 @@ namespace Octokit.GraphQL
         /// </summary>
         /// <param name="owner">The login field of a user or organization</param>
         /// <param name="name">The name of the repository</param>
-        public Repository Repository(string owner, string name) => this.CreateMethodCall(x => x.Repository(owner, name), Octokit.GraphQL.Model.Repository.Create);
+        public Repository Repository(Arg<string> owner, Arg<string> name) => this.CreateMethodCall(x => x.Repository(owner, name), Octokit.GraphQL.Model.Repository.Create);
 
         /// <summary>
         /// Lookup a repository owner (ie. either a User or an Organization) by login.
         /// </summary>
         /// <param name="login">The username to lookup the owner by.</param>
-        public IRepositoryOwner RepositoryOwner(string login) => this.CreateMethodCall(x => x.RepositoryOwner(login), Octokit.GraphQL.Model.Internal.StubIRepositoryOwner.Create);
+        public IRepositoryOwner RepositoryOwner(Arg<string> login) => this.CreateMethodCall(x => x.RepositoryOwner(login), Octokit.GraphQL.Model.Internal.StubIRepositoryOwner.Create);
 
         /// <summary>
         /// Lookup resource by a URL.
         /// </summary>
         /// <param name="url">The URL.</param>
-        public IUniformResourceLocatable Resource(string url) => this.CreateMethodCall(x => x.Resource(url), Octokit.GraphQL.Model.Internal.StubIUniformResourceLocatable.Create);
+        public IUniformResourceLocatable Resource(Arg<string> url) => this.CreateMethodCall(x => x.Resource(url), Octokit.GraphQL.Model.Internal.StubIUniformResourceLocatable.Create);
 
         /// <summary>
         /// Perform a search across resources.
@@ -139,19 +139,19 @@ namespace Octokit.GraphQL
         /// <param name="before">Returns the elements in the list that come before the specified global ID.</param>
         /// <param name="query">The search string to look for.</param>
         /// <param name="type">The types of search items to search within.</param>
-        public SearchResultItemConnection Search(string query, SearchType type, int? first = null, string after = null, int? last = null, string before = null) => this.CreateMethodCall(x => x.Search(query, type, first, after, last, before), Octokit.GraphQL.Model.SearchResultItemConnection.Create);
+        public SearchResultItemConnection Search(Arg<string> query, Arg<SearchType> type, Arg<int>? first = null, Arg<string>? after = null, Arg<int>? last = null, Arg<string>? before = null) => this.CreateMethodCall(x => x.Search(query, type, first, after, last, before), Octokit.GraphQL.Model.SearchResultItemConnection.Create);
 
         /// <summary>
         /// Look up a topic by name.
         /// </summary>
         /// <param name="name">The topic's name.</param>
-        public Topic Topic(string name) => this.CreateMethodCall(x => x.Topic(name), Octokit.GraphQL.Model.Topic.Create);
+        public Topic Topic(Arg<string> name) => this.CreateMethodCall(x => x.Topic(name), Octokit.GraphQL.Model.Topic.Create);
 
         /// <summary>
         /// Lookup a user by login.
         /// </summary>
         /// <param name="login">The user's login.</param>
-        public User User(string login) => this.CreateMethodCall(x => x.User(login), Octokit.GraphQL.Model.User.Create);
+        public User User(Arg<string> login) => this.CreateMethodCall(x => x.User(login), Octokit.GraphQL.Model.User.Create);
 
         /// <summary>
         /// The currently authenticated user.


### PR DESCRIPTION
This PR provides an initial implementation of variables, which can be passed to a query in a dictionary. This is how it works:

## Arguments replaced with Arg<T>

The `struct Arg<T>` type was added. All arguments are now of type `Arg<T>` (for non-nullable arguments) and `Arg<T>?` (for nullable arguments).

There is an implict conversion from `T` to `Arg<T>` so queries without variables work as before.

## Variables are Inserted into Queries

To insert a variable into a query, you use the type `struct Variable`. `Variable` has a single member - the variable name - and is implicitly convertible to `Arg<T>`.

There is also the method `Variable.Var` which means that `using static` can be used to insert variables into queries less verbosely:

```csharp
using static Octokit.GraphQL.Variable;

var query = new TestQuery()
    .Simple(Var("var1"))
    .Select(x => x.Name);
```

This inserts a variable called `$var1` into the query.

## The Query is compiled

Calling `.Compile()` on a query causes the expression to be rewritten and the query to be serialized:

```csharp
using static Octokit.GraphQL.Variable;

var query = new TestQuery()
    .Simple(Var("var1"))
    .Select(x => x.Name)
    .Compile();
```

## Values for Variables are Passed to Connection.Run

`Connection.Run` now accepts a dictionary of `string` -> `object` values which will be passed as variables:

```csharp
using static Octokit.GraphQL.Variable;

var query = new TestQuery()
    .Simple(Var("var1"))
    .Select(x => x.Name)
    .Compile();

var vars = new Dictionary<string, object>
{
    { "var1", "foo" }
};

var result = connection.Run(query, vars);
```