### PR TITLE
Use correct nullability of argument type for variables.

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -502,7 +502,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void SimpleQuery_Variable()
         {
-            var expected = "query($var1:String){simple(arg1:$var1){name}}";
+            var expected = "query($var1:String!){simple(arg1:$var1){name}}";
 
             var expression = new TestQuery()
                 .Simple(Var("var1"))
@@ -530,7 +530,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void InputObject_Variable()
         {
-            var expected = "query($var1:InputObject){inputObject(input:$var1){name}}";
+            var expected = "query($var1:InputObject!){inputObject(input:$var1){name}}";
 
             var expression = new TestQuery()
                 .InputObject(Var("var1"))

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -565,7 +565,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Multiple_Variables()
         {
-            var expected = "query($foo:String,$bar:Int){simple(arg1:$foo,arg2:$bar){name}}";
+            var expected = "query($foo:String!,$bar:Int){simple(arg1:$foo,arg2:$bar){name}}";
 
             var expression = new TestQuery()
                 .Simple(Var("foo"), Var("bar"))

--- a/Octokit.GraphQL.Core/Core/Arg.cs
+++ b/Octokit.GraphQL.Core/Core/Arg.cs
@@ -4,25 +4,41 @@ namespace Octokit.GraphQL.Core
 {
     public struct Arg<T> : IArg
     {
-        private Arg(string name, T value)
+        bool isNullableVariable;
+
+        private Arg(T value)
         {
-            VariableName = name;
+            VariableName = null;
             Value = value;
+            isNullableVariable = false;
+        }
+
+        private Arg(string variableName, bool isNullable)
+        {
+            VariableName = variableName;
+            Value = default(T);
+            isNullableVariable = isNullable;
         }
 
         public string VariableName { get; }
         public T Value { get; }
+        bool IArg.IsNullableVariable => isNullableVariable;
         Type IArg.Type => typeof(T);
         object IArg.Value => Value;
 
         public static implicit operator Arg<T>(T value)
         {
-            return new Arg<T>(null, value);
+            return new Arg<T>(value);
         }
 
         public static implicit operator Arg<T>(Variable variable)
         {
-            return new Arg<T>(variable.Name, default(T));
+            return new Arg<T>(variable.Name, false);
+        }
+
+        public static implicit operator Arg<T>?(Variable variable)
+        {
+            return new Arg<T>(variable.Name, true);
         }
     }
 }

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -444,7 +444,7 @@ namespace Octokit.GraphQL.Core.Builders
                     }
                     else
                     {
-                        value = syntax.AddVariableDefinition(arg.Type, arg.VariableName);
+                        value = syntax.AddVariableDefinition(arg.Type, arg.IsNullableVariable, arg.VariableName);
                     }
                 }
 

--- a/Octokit.GraphQL.Core/Core/IArg.cs
+++ b/Octokit.GraphQL.Core/Core/IArg.cs
@@ -4,6 +4,7 @@ namespace Octokit.GraphQL.Core
 {
     internal interface IArg
     {
+        bool IsNullableVariable { get; }
         Type Type { get; }
         string VariableName { get; }
         object Value { get; }

--- a/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
@@ -50,17 +50,17 @@ namespace Octokit.GraphQL.Core.Syntax
             return result;
         }
 
-        public VariableDefinition AddVariableDefinition(Type type, string name)
+        public VariableDefinition AddVariableDefinition(Type type, bool isNullable, string name)
         {
             var result = root.VariableDefinitions.SingleOrDefault(x => x.Name == name);
 
-            if (result != null && result.Type != VariableDefinition.ToTypeName(type))
+            if (result != null && result.Type != VariableDefinition.ToTypeName(type, isNullable))
             {
                 throw new InvalidOperationException(
                     $"A variable called '{name}' has already been added with a different type.");
             }
 
-            result = result ?? new VariableDefinition(type, name);
+            result = result ?? new VariableDefinition(type, isNullable, name);
             root.VariableDefinitions.Add(result);
             return result;
         }

--- a/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/VariableDefinition.cs
@@ -6,16 +6,16 @@ namespace Octokit.GraphQL.Core.Syntax
 {
     public class VariableDefinition
     {
-        public VariableDefinition(Type type, string name)
+        public VariableDefinition(Type type, bool isNullable, string name)
         {
-            Type = ToTypeName(type);
+            Type = ToTypeName(type, isNullable);
             Name = name;
         }
 
         public string Type { get; }
         public string Name { get; }
 
-        public static string ToTypeName(Type type)
+        public static string ToTypeName(Type type, bool isNullable)
         {
             if (type == typeof(int))
             {
@@ -30,7 +30,7 @@ namespace Octokit.GraphQL.Core.Syntax
                 return "Boolean";
             }
 
-            return type.Name;
+            return type.Name + (isNullable ? "" : "!");
         }
     }
 }

--- a/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/RepositoryTests.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
 using System.Linq;
 using Octokit.GraphQL.Core;
 using Octokit.GraphQL.IntegrationTests.Utilities;
 using Octokit.GraphQL.Model;
 using Xunit;
+using static Octokit.GraphQL.Variable;
 
 namespace Octokit.GraphQL.IntegrationTests.Queries
 {
@@ -72,6 +74,24 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.Contains("octokit.objc", repositoryNames);
             Assert.Contains("go-octokit", repositoryNames);
             Assert.Contains("discussions", repositoryNames);
+        }
+
+        [IntegrationTest]
+        public void Should_Query_Repository_With_Variables()
+        {
+            var query = new Query()
+                .Repository(Var("owner"), Var("name"))
+                .Select(repository => repository.Name)
+                .Compile();
+            var vars = new Dictionary<string, object>
+            {
+                { "owner", "octokit" },
+                { "name", "octokit.net" },
+            };
+
+            var repositoryName = Connection.Run(query, vars).Result;
+
+            Assert.Equal("octokit.net", repositoryName);
         }
 
         [IntegrationTest(Skip = "Querying unions like this no longer works")]


### PR DESCRIPTION
Store nullability in `Arg<>` and use that nullability state when serializing the query.

Fixes #66 