### PR TITLE
Make Connection.Run virtual.

### DIFF
--- a/Octokit.GraphQL.Core/Connection.cs
+++ b/Octokit.GraphQL.Core/Connection.cs
@@ -15,8 +15,6 @@ namespace Octokit.GraphQL
         /// </summary>
         public static readonly Uri GithubApiUri = new Uri("https://api.github.com/graphql");
 
-        private readonly ICredentialStore credentialStore;
-        private readonly HttpClient httpClient;
 
         public Connection(ProductHeaderValue productInformation, string token)
             : this(productInformation, GithubApiUri, token)
@@ -36,25 +34,32 @@ namespace Octokit.GraphQL
         public Connection(ProductHeaderValue productInformation, Uri uri, ICredentialStore credentialStore)
         {
             Uri = uri;
-            this.credentialStore = credentialStore;
-            httpClient = CreateHttpClient(productInformation);
+            CredentialStore = credentialStore;
+            HttpClient = CreateHttpClient(productInformation);
         }
 
         public Uri Uri { get; }
+        protected ICredentialStore CredentialStore { get; }
+        protected HttpClient HttpClient { get; }
 
-        public async Task<T> Run<T>(
+        public virtual async Task<T> Run<T>(
             CompiledQuery<T> query,
             IDictionary<string, object> variables = null)
         {
             var payload = query.GetPayload(variables);
-            var token = await credentialStore.GetCredentials();
+            var data = await Send(payload);
+            var deserializer = new ResponseDeserializer();
+            return deserializer.Deserialize(query, data);
+        }
+
+        protected async Task<string> Send(string payload)
+        {
+            var token = await CredentialStore.GetCredentials();
             var request = new HttpRequestMessage(HttpMethod.Post, Uri);
             request.Content = new StringContent(payload);
             request.Headers.Authorization = new AuthenticationHeaderValue("bearer", token);
-            var response = await httpClient.SendAsync(request);
-            var data = await response.Content.ReadAsStringAsync();
-            var deserializer = new ResponseDeserializer();
-            return deserializer.Deserialize(query, data);
+            var response = await HttpClient.SendAsync(request);
+            return await response.Content.ReadAsStringAsync();
         }
 
         private HttpClient CreateHttpClient(ProductHeaderValue header)

--- a/Octokit.GraphQL.IntegrationTests/Queries/ErrorTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/ErrorTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Octokit.GraphQL.Core;
+using Octokit.GraphQL.IntegrationTests.Utilities;
+using Xunit;
+
+namespace Octokit.GraphQL.IntegrationTests.Queries
+{
+    public class ErrorTests : IntegrationTestBase
+    {
+        [IntegrationTest]
+        public async Task Should_Throw_Correct_Error_For_Name_Resolution_Failure()
+        {
+            var query = new GraphQL.Query().Repository("octokit", "octokit.net")
+                .Issues(first: 3).Nodes.Select(i => new
+                {
+                    i.Title,
+                    RepositoryName = i.Repository.Name,
+                });
+
+            var connection = new Connection(
+                new ProductHeaderValue("OctokitTests"),
+                new Uri("https://invalid.github.123"), 
+                Helper.OAuthToken);
+
+            var ex = await Assert.ThrowsAnyAsync<Exception>(async () => await connection.Run(query));
+
+            Assert.IsType<HttpRequestException>(ex);
+            Assert.IsType<WebException>(ex.InnerException);
+            Assert.Equal(WebExceptionStatus.NameResolutionFailure, ((WebException)ex.InnerException).Status);
+        }
+
+        [IntegrationTest]
+        public async Task Should_Throw_Correct_Error_For_Invalid_Repository_Name()
+        {
+            var query = new GraphQL.Query().Repository("octokit", "bad_repository")
+                .Issues(first: 3).Nodes.Select(i => new
+                {
+                    i.Title,
+                    RepositoryName = i.Repository.Name,
+                });
+
+            var ex = await Assert.ThrowsAnyAsync<GraphQLQueryException>(async () => await Connection.Run(query));
+            Assert.Equal("Could not resolve to a Repository with the name 'bad_repository'.", ex.Message);
+            Assert.Equal(1, ex.Line);
+            Assert.Equal(7, ex.Column);
+        }
+    }
+}


### PR DESCRIPTION
In GitHub for Visual Studio we want to add a caching layer above the connection. The easiest way to allow this is to make `Connection.Run` virtual and add a protected `Run(string)` method that can be called in the case of a cache miss.