### PR TITLE
Return concrete classes from ToList/ToDictionary.

### DIFF
--- a/Octokit.GraphQL.Core/Core/Builders/Rewritten.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/Rewritten.cs
@@ -63,7 +63,7 @@ namespace Octokit.GraphQL.Core.Builders
                 return source.Select(selector);
             }
 
-            public static IDictionary<TKey, TElement> ToDictionary<TKey, TElement>(
+            public static Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(
                 IEnumerable<JToken> source,
                 Func<JToken, TKey> keySelector,
                 Func<JToken, TElement> elementSelector)
@@ -71,7 +71,7 @@ namespace Octokit.GraphQL.Core.Builders
                 return source.ToDictionary(keySelector, elementSelector);
             }
 
-            public static IList<TResult> ToList<TResult>(IEnumerable<JToken> source)
+            public static List<TResult> ToList<TResult>(IEnumerable<JToken> source)
             {
                 return source.Select(x => x.ToObject<TResult>()).ToList();
             }

--- a/Octokit.GraphQL.Core/QueryableListExtensions.cs
+++ b/Octokit.GraphQL.Core/QueryableListExtensions.cs
@@ -52,7 +52,7 @@ namespace Octokit.GraphQL
         }
 
         [MethodId(nameof(ToListMethod))]
-        public static IList<TValue> ToList<TValue>(this IQueryableList<TValue> source)
+        public static List<TValue> ToList<TValue>(this IQueryableList<TValue> source)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Returning in interfaces wasn't ideal as these don't implement the readonly interfaces (i.e. `IReadOnlyList`). The `Enumerable.ToList`/`ToDictionary` extension methods return the concrete collection types so do the same here.