### PR TITLE
Added ID Type.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 1.1.5
+dotnet: 2.0.0
 script:
  - dotnet restore
  - dotnet build
@@ -8,3 +8,10 @@ script:
  - dotnet test ./Octokit.GraphQL.UnitTests/Octokit.GraphQL.UnitTests.csproj
  - dotnet test ./Octokit.GraphQL.Core.Generation.UnitTests/Octokit.GraphQL.Core.Generation.UnitTests.csproj
  - dotnet test ./Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+ addons:
+  apt:
+    sources:
+    - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main'
+      key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
+    packages:
+    - dotnet-sharedframework-microsoft.netcore.app-1.1.8

--- a/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/EntityGenerationTests.cs
@@ -181,6 +181,54 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         }
 
         [Fact]
+        public void Generates_Property_For_ID_Field()
+        {
+            var expected = FormatMemberTemplate("public ID? Foo { get; }");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.ID(),
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            CompareModel("Entity.cs", expected, result);
+        }
+
+        [Fact]
+        public void Generates_Property_For_NonNull_ID_Field()
+        {
+            var expected = FormatMemberTemplate("public ID Foo { get; }");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.NonNull(TypeModel.ID())
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            CompareModel("Entity.cs", expected, result);
+        }
+
+        [Fact]
         public void Generates_Property_For_Object_Field()
         {
             var expected = FormatMemberTemplate("public Other Foo => this.CreateProperty(x => x.Foo, Test.Other.Create);");
@@ -780,6 +828,38 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
         }
 
         [Fact]
+        public void Generates_Method_For_Object_Field_With_ID_Arg()
+        {
+            var expected = FormatMemberTemplate("public Other Foo(Arg<ID> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.Object("Other"),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "bar",
+                                Type = TypeModel.NonNull(TypeModel.ID()),
+                            }
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            CompareModel("Entity.cs", expected, result);
+        }
+
+        [Fact]
         public void Generates_Method_For_NonNull_Object_Field_With_Args()
         {
             var expected = FormatMemberTemplate("public Other Foo(Arg<int> bar) => this.CreateMethodCall(x => x.Foo(bar), Test.Other.Create);");
@@ -1149,6 +1229,70 @@ namespace Octokit.GraphQL.Core.Generation.UnitTests
                     {
                         Name = "foo",
                         Type = TypeModel.NonNull(TypeModel.Int()),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "bar",
+                                Type = TypeModel.Int(),
+                            }
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            CompareModel("Entity.cs", expected, result);
+        }
+
+        [Fact]
+        public void Generates_Method_For_ID_Field()
+        {
+            var expected = FormatMemberTemplate("public ID? Foo(Arg<int>? bar = null) => null;");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.ID(),
+                        Args = new[]
+                        {
+                            new InputValueModel
+                            {
+                                Name = "bar",
+                                Type = TypeModel.Int(),
+                            }
+                        }
+                    },
+                }
+            };
+
+            var result = CodeGenerator.Generate(model, "Test", null);
+
+            CompareModel("Entity.cs", expected, result);
+        }
+
+        [Fact]
+        public void Generates_Method_For_NonNull_ID_Field()
+        {
+            var expected = FormatMemberTemplate("public ID Foo(Arg<int>? bar = null) => null;");
+
+            var model = new TypeModel
+            {
+                Name = "Entity",
+                Kind = TypeKind.Object,
+                Fields = new[]
+                {
+                    new FieldModel
+                    {
+                        Name = "foo",
+                        Type = TypeModel.NonNull(TypeModel.ID()),
                         Args = new[]
                         {
                             new InputValueModel

--- a/Octokit.GraphQL.Core.Generation.UnitTests/Octokit.GraphQL.Core.Generation.UnitTests.csproj
+++ b/Octokit.GraphQL.Core.Generation.UnitTests/Octokit.GraphQL.Core.Generation.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/Octokit.GraphQL.Core.Generation/Models/TypeModel.cs
+++ b/Octokit.GraphQL.Core.Generation/Models/TypeModel.cs
@@ -68,6 +68,15 @@ namespace Octokit.GraphQL.Core.Generation.Models
             };
         }
 
+        public static TypeModel ID()
+        {
+            return new TypeModel
+            {
+                Kind = TypeKind.Scalar,
+                Name = "ID",
+            };
+        }
+
         public static TypeModel Interface(string name)
         {
             return new TypeModel

--- a/Octokit.GraphQL.Core.Generation/Octokit.GraphQL.Core.Generation.csproj
+++ b/Octokit.GraphQL.Core.Generation/Octokit.GraphQL.Core.Generation.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL.Core\Octokit.GraphQL.Core.csproj" />

--- a/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
+++ b/Octokit.GraphQL.Core.Generation/Utilities/TypeUtilities.cs
@@ -126,6 +126,7 @@ namespace Octokit.GraphQL.Core.Generation.Utilities
                         case "Float": return "double" + question;
                         case "String": return "string";
                         case "Boolean": return "bool" + question;
+                        case "ID": return "ID" + question;
                         case "GitTimeStamp": return "DateTimeOffset" + question;
                         case "DateTime": return "DateTimeOffset" + question;
                         default: return "string";
@@ -151,7 +152,12 @@ namespace Octokit.GraphQL.Core.Generation.Utilities
         private static bool IsValueType(TypeModel type)
         {
             return type.Kind == TypeKind.Enum ||
-                (type.Kind == TypeKind.Scalar && (type.Name == "Int" || type.Name == "Float" || type.Name == "Boolean" || type.Name == "DateTime"));
+                (type.Kind == TypeKind.Scalar && 
+                   (type.Name == "Int" ||
+                    type.Name == "Float" || 
+                    type.Name == "Boolean" || 
+                    type.Name == "DateTime" ||
+                    type.Name == "ID"));
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
+++ b/Octokit.GraphQL.Core.UnitTests/Models/TestQuery.cs
@@ -55,6 +55,11 @@ namespace Octokit.GraphQL.Core.UnitTests.Models
             return this.CreateMethodCall(x => x.EnumerableValue(value), Models.Simple.Create);
         }
 
+        public Simple IdValue(Arg<ID> id)
+        {
+            return this.CreateMethodCall(x => x.IdValue(id), Models.Simple.Create);
+        }
+
         public Simple InputObject(Arg<InputObject> input)
         {
             return this.CreateMethodCall(x => x.InputObject(input), Models.Simple.Create);

--- a/Octokit.GraphQL.Core.UnitTests/Octokit.GraphQL.Core.UnitTests.csproj
+++ b/Octokit.GraphQL.Core.UnitTests/Octokit.GraphQL.Core.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -333,6 +333,20 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
+        public void ID_Parameter()
+        {
+            var expected = "query{idValue(id:\"123\"){name}}";
+
+            var expression = new TestQuery()
+                .IdValue(new ID("123"))
+                .Select(x => x.Name);
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.Query);
+        }
+
+        [Fact]
         public void InputObject_Parameter()
         {
             var expected = "query{inputObject(input:{stringValue:\"foo\"}){name}}";

--- a/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
+++ b/Octokit.GraphQL.Core/Core/Serializers/QuerySerializer.cs
@@ -169,6 +169,10 @@ namespace Octokit.GraphQL.Core.Serializers
             {
                 builder.Append(value);
             }
+            else if (value is ID id)
+            {
+                builder.Append(JsonConvert.ToString(id.Value, '"'));
+            }
             else if (value is IEnumerable)
             {
                 builder.Append("[");

--- a/Octokit.GraphQL.Core/ID.cs
+++ b/Octokit.GraphQL.Core/ID.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Newtonsoft.Json;
+using Octokit.GraphQL.Internal;
+
+namespace Octokit.GraphQL
+{
+    /// <summary>
+    /// Represents a unique identifier.
+    /// </summary>
+    [JsonConverter(typeof(IDConverter))]
+    public readonly struct ID
+    {
+        /// <summary>
+        /// Generates a new instance of the <see cref="ID"/> struct.
+        /// </summary>
+        /// <param name="value">The ID string.</param>
+        public ID(string value)
+        {
+            Value = value;
+        }
+        
+        /// <summary>
+        /// Gets the ID as a string value.
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// Converts the ID to a string.
+        /// </summary>
+        /// <returns>The ID as a string.</returns>
+        public override string ToString() => Value;
+    }
+}

--- a/Octokit.GraphQL.Core/Internal/IDConverter.cs
+++ b/Octokit.GraphQL.Core/Internal/IDConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Octokit.GraphQL.Internal
+{
+    /// <summary>
+    /// Converts <see cref="ID"/>s to and from JSON strings.
+    /// </summary>
+    class IDConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) => objectType == typeof(ID);
+ 
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, ((ID)value).Value);
+        }
+
+        public override bool CanRead => true;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return new ID(serializer.Deserialize<string>(reader));
+        }
+    }
+}

--- a/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
+++ b/Octokit.GraphQL.Core/Octokit.GraphQL.Core.csproj
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DocumentationFile>bin\$(Configuration)\netstandard1.1\Octokit.GraphQL.Core.xml</DocumentationFile>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
+++ b/Octokit.GraphQL.IntegrationTests/Octokit.GraphQL.IntegrationTests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <AssemblyName>Octokit.GraphQL.IntegrationTests</AssemblyName>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/Octokit.GraphQL.UnitTests/Octokit.GraphQL.UnitTests.csproj
+++ b/Octokit.GraphQL.UnitTests/Octokit.GraphQL.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/Octokit.GraphQL/Octokit.GraphQL.csproj
+++ b/Octokit.GraphQL/Octokit.GraphQL.csproj
@@ -5,6 +5,7 @@
     <AssemblyOriginatorKeyFile>..\key.snk</AssemblyOriginatorKeyFile>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DocumentationFile>bin\$(Configuration)\netstandard1.1\Octokit.GraphQL.xml</DocumentationFile>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octokit.GraphQL.Core\Octokit.GraphQL.Core.csproj" />

--- a/Tools/Generate/Generate.csproj
+++ b/Tools/Generate/Generate.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.1</TargetFramework>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Octokit.GraphQL.Core.Generation\Octokit.GraphQL.Core.Generation.csproj" />


### PR DESCRIPTION
The [`ID`](http://facebook.github.io/graphql/October2016/#sec-ID) type is a built-in scalar in GraphQL and needs to be represented by a real type in C# in order for it to be usable as a variable.

This PR adds a `struct ID` type and updates the entity generation to use this type. `ID` is immutable so also updated the C# version to 7.2 in order to get the `readonly struct` feature.

The actual models aren't updated in this PR to reduce noise.