### PR TITLE
Make Manual Paging by Node ID work.

### DIFF
--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Octokit.GraphQL.IntegrationTests.Utilities;
 using Octokit.GraphQL.Model;
 using Xunit;
@@ -96,6 +97,56 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
                 }).Compile();
 
             var results = Connection.Run(query).Result;
+        }
+
+        [IntegrationTest]
+        public async Task Can_Manually_Page_Issues_By_Node_Id()
+        {
+            var openState = new[] { IssueState.Closed };
+            var masterQuery = new Query()
+                .Repository("octokit", "octokit.net")
+                .Issue(405)
+                .Select(issue => new
+                {
+                    issue.Id,
+                    Comments = issue.Comments(100, null, null, null).Select(page => new
+                    {
+                        page.PageInfo.HasNextPage,
+                        page.PageInfo.EndCursor,
+                        Items = page.Nodes.Select(comment => comment.Body).ToList(),
+                    }).Single(),
+                });
+
+            var pageQuery = new Query()
+                .Node(Var("issueId"))
+                .Cast<Model.Issue>()
+                .Comments(100, Var("after"))
+                .Select(page => new
+                {
+                    page.PageInfo.HasNextPage,
+                    page.PageInfo.EndCursor,
+                    Items = page.Nodes.Select(comment => comment.Body).ToList(),
+                }).Compile();
+
+            var result = await Connection.Run(masterQuery);
+
+            Assert.True(result.Comments.HasNextPage);
+
+            var vars = new Dictionary<string, object>
+            {
+                { "issueId", result.Id },
+                { "after", result.Comments.EndCursor },
+            };
+
+            do
+            {
+
+                var pageResults = await Connection.Run(pageQuery, vars);
+                result.Comments.Items.AddRange(pageResults.Items);
+                vars["after"] = pageResults.HasNextPage ? pageResults.EndCursor : null;
+            } while (vars["after"] != null);
+
+            Assert.True(result.Comments.Items.Count > 100);
         }
 
         [IntegrationTest(Skip = "Querying unions like this no longer works")]

--- a/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/IssueTests.cs
@@ -102,7 +102,6 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
         [IntegrationTest]
         public async Task Can_Manually_Page_Issues_By_Node_Id()
         {
-            var openState = new[] { IssueState.Closed };
             var masterQuery = new Query()
                 .Repository("octokit", "octokit.net")
                 .Issue(405)


### PR DESCRIPTION
Manual paging wasn't working for a few reasons:

- Needed a `ID` type (implemented in #78)
- `Cast<T>` was returning the wrong type

Depends on #79.