### PR TITLE
Fix conditional expressions with null.

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
@@ -232,5 +232,21 @@ namespace Octokit.GraphQL.Core.UnitTests
             var query = expression.Compile();
             Assert.Equal(expected.ToString(), query.Expression.ToString());
         }
+
+        [Fact]
+        public void Can_Use_Conditional_With_Null()
+        {
+            var expression = new TestQuery()
+                .Simple("foo", 2)
+                .Select(x => !string.IsNullOrWhiteSpace(x.Name) ? x.Name : null);
+
+            Expression<Func<JObject, object>> expected = data =>
+                Rewritten.Value.Select(
+                    data["data"]["simple"],
+                    x => !string.IsNullOrWhiteSpace(x["name"].ToObject<string>()) ? x["name"] : null).ToObject<string>();
+
+            var query = expression.Compile();
+            Assert.Equal(expected.ToString(), query.Expression.ToString());
+        }
     }
 }

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -40,12 +40,4 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.Equal("master", result);
         }
     }
-
-    public class GitReferenceModel
-    {
-        public GitReferenceModel(string @ref, string label, string sha, string repositoryCloneUri)
-        {
-        }
-    }
-
 }

--- a/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
+++ b/Octokit.GraphQL.IntegrationTests/Queries/PullRequestTests.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Octokit.GraphQL.IntegrationTests.Utilities;
 using Xunit;
 
@@ -25,5 +26,26 @@ namespace Octokit.GraphQL.IntegrationTests.Queries
             Assert.Equal(expectedMessage, (string)results[0].Message);
             Assert.Equal((string)"Haacked", (string)results[0].Name);
         }
+
+        [IntegrationTest]
+        public async Task Can_Use_Conditional_In_BaseRef_Query()
+        {
+            var query = new Query()
+                .Repository("octokit", "octokit.net")
+                .PullRequest(1)
+                .Select(pr => pr.BaseRef != null ? pr.BaseRef.Name : null);
+
+            var result = await Connection.Run(query);
+
+            Assert.Equal("master", result);
+        }
     }
+
+    public class GitReferenceModel
+    {
+        public GitReferenceModel(string @ref, string label, string sha, string repositoryCloneUri)
+        {
+        }
+    }
+
 }


### PR DESCRIPTION
When a conditional expression has one side which is null, need to ensure the type of the null constant is the same as the other side of the conditional.

Fixes #82.