### PR TITLE
 Add typename outside fragment.

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -197,7 +197,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Inline_Fragment()
         {
-            var expected = "query{queryItems{... on NestedData{__typename id nestedItems{name}}}}";
+            var expected = "query{queryItems{__typename ... on NestedData{id nestedItems{name}}}}";
 
             var expression = new TestQuery()
                 .QueryItems
@@ -446,8 +446,8 @@ namespace Octokit.GraphQL.Core.UnitTests
         {
             var expected = @"query {
   union {
+    __typename
     ... on Simple {
-      __typename
       name
       description
     }
@@ -473,8 +473,8 @@ namespace Octokit.GraphQL.Core.UnitTests
         {
             var expected = @"query {
   union {
+    __typename
     ... on Simple {
-      __typename
       name
     }
   }
@@ -494,8 +494,8 @@ namespace Octokit.GraphQL.Core.UnitTests
         {
             var expected = @"query {
   union {
+    __typename
     ... on Simple {
-      __typename
       name
     }
   }
@@ -560,8 +560,8 @@ namespace Octokit.GraphQL.Core.UnitTests
         {
             var expected = @"query {
   node(id: 123) {
+    __typename
     ... on Simple {
-      __typename
       name
     }
   }

--- a/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
+++ b/Octokit.GraphQL.Core/Core/Syntax/SyntaxTree.cs
@@ -42,7 +42,7 @@ namespace Octokit.GraphQL.Core.Syntax
 
             if (selectTypeName)
             {
-                result.Selections.Add(new FieldSelection("__typename", null));
+                Head.Selections.Add(new FieldSelection("__typename", null));
             }
 
             head.Selections.Add(result);

--- a/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
@@ -145,8 +145,8 @@ namespace Octokit.GraphQL.UnitTests
     userCount
     edges {
       node {
+        __typename
         ... on User {
-          __typename
           id
           login
           avatarUrl
@@ -240,8 +240,8 @@ namespace Octokit.GraphQL.UnitTests
             var expected = @"query {
   search(query: ""foo"", type: USER, first: 30) {
     nodes {
+      __typename
       ... on User {
-        __typename
         name
       }
     }
@@ -264,8 +264,8 @@ namespace Octokit.GraphQL.UnitTests
             var expected = @"query {
   search(query: ""foo"", type: USER, first: 30) {
     nodes {
+      __typename
       ... on User {
-        __typename
         name
         login
       }


### PR DESCRIPTION
When selecting an interface, union etc then the `__typename` fragment should be added outside the inline fragment, or it will not be selected in the case of the object being of the wrong type.