### PR TITLE
Fix needed to properly alias queries

### DIFF
--- a/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
@@ -115,7 +115,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     {
                         Value = Rewritten.Value.Single(
                             Rewritten.Value.Select(
-                                x["milestone"],
+                                x["value"],
                                 y => new
                                 {
                                     Closed = y["closed"].ToObject<bool>(),
@@ -149,7 +149,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     {
                         Value = Rewritten.Value.SingleOrDefault(
                             Rewritten.Value.Select(
-                                x["milestone"],
+                                x["value"],
                                 y => new
                                 {
                                     Closed = y["closed"].ToObject<bool>(),

--- a/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ExpressionRewiterTests.cs
@@ -86,7 +86,7 @@ namespace Octokit.GraphQL.Core.UnitTests
                     x => new
                     {
                         Body = x["body"].ToObject<string>(),
-                        Items = Rewritten.List.ToList<string>(Rewritten.List.Select(x["conditions"], i => i["description"]))
+                        Items = Rewritten.List.ToList<string>(Rewritten.List.Select(x["items"], i => i["description"]))
                     }).ToList();
 
             var query = expression.Compile();

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -80,7 +80,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Cast_Member_To_Enum()
         {
-            var expected = "query{repository(owner:\"foo\",name:\"bar\"){enum:forkCount}}";
+            var expected = "query{repository(owner:\"foo\",name:\"bar\"){enum: forkCount}}";
 
             var expression = new Query()
                 .Repository("foo", "bar")

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -558,8 +558,8 @@ namespace Octokit.GraphQL.Core.UnitTests
             var expression = new Query()
                 .Select(q => new
                 {
-                    repo1 = q.Repository("foo", "bar").Select(repository => new { repository.Name }),
-                    repo2 = q.Repository("foo", "bar").Select(repository => new { repository.Name })
+                    repo1 = q.Repository("foo", "bar").Select(repository => new { repository.Name }).Single(),
+                    repo2 = q.Repository("foo", "bar").Select(repository => new { repository.Name }).Single()
                 });
 
             var query = expression.Compile();

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -597,7 +597,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = expression.Compile();
 
-            Assert.Equal(expected, query.ToString(2));
+            Assert.Equal(expected, query.ToString(2), ignoreLineEndingDifferences: true);
         }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -218,7 +218,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = expression.Compile();
 
-            Assert.Equal(expected, query.ToString(2));
+            Assert.Equal(expected, query.ToString(2), ignoreLineEndingDifferences: true);
         }
 
         [Fact]

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -97,11 +97,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Cast_Nullable_Member_To_Enum()
         {
-            var expected = @"query {
-  repository(owner: ""foo"", name: ""bar"") {
-    enum: databaseId
-  }
-}";
+            var expected = "query{repository(owner:\"foo\",name:\"bar\"){enum: databaseId}}";
 
             var expression = new Query()
                 .Repository("foo", "bar")
@@ -112,7 +108,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = expression.Compile();
 
-            Assert.Equal(expected, query.ToString(2));
+            Assert.Equal(expected, query.ToString(0));
         }
 
         [Fact]

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -161,7 +161,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Licenses_Nested_Selects()
         {
-            var expected = "query{licenses{body items:conditions{description}}}";
+            var expected = "query{licenses{body items: conditions{description}}}";
 
             var expression = new Query()
                 .Licenses

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -80,7 +80,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Cast_Member_To_Enum()
         {
-            var expected = "query{repository(owner:\"foo\",name:\"bar\"){forkCount}}";
+            var expected = "query{repository(owner:\"foo\",name:\"bar\"){enum:forkCount}}";
 
             var expression = new Query()
                 .Repository("foo", "bar")
@@ -97,7 +97,11 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Cast_Nullable_Member_To_Enum()
         {
-            var expected = "query{repository(owner:\"foo\",name:\"bar\"){databaseId}}";
+            var expected = @"query {
+  repository(owner: ""foo"", name: ""bar"") {
+    enum: databaseId
+  }
+}";
 
             var expression = new Query()
                 .Repository("foo", "bar")
@@ -108,7 +112,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = expression.Compile();
 
-            Assert.Equal(expected, query.ToString(0));
+            Assert.Equal(expected, query.ToString(2));
         }
 
         [Fact]
@@ -175,7 +179,13 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Issues_Nested_Select_With_Captured_Parameter()
         {
-            var expected = "query{repository(owner:\"foo\",name:\"bar\"){issues(first:10,after:\"foo\"){totalCount}}}";
+            var expected = @"query {
+  repository(owner: ""foo"", name: ""bar"") {
+    items: issues(first: 10, after: ""foo"") {
+      totalCount
+    }
+  }
+}";
 
             var arg1 = "foo";
             var expression = new Query()
@@ -190,7 +200,7 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             var query = expression.Compile();
 
-            Assert.Equal(expected, query.ToString(0));
+            Assert.Equal(expected, query.ToString(2));
         }
 
         [Fact]

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -532,5 +532,29 @@ namespace Octokit.GraphQL.Core.UnitTests
 
             Assert.Equal(expected, query.ToString(0));
         }
+
+        [Fact]
+        public void Can_Select_Repo_Twice()
+        {
+            var expected = @"query {
+  repo1: repository(owner: ""foo"", name: ""bar"") {
+    name
+  }
+  repo2: repository(owner: ""foo"", name: ""bar"") {
+    name
+  }
+}";
+
+            var expression = new Query()
+                .Select(q => new
+                {
+                    repo1 = q.Repository("foo", "bar").Select(repository => new { repository.Name }),
+                    repo2 = q.Repository("foo", "bar").Select(repository => new { repository.Name })
+                });
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.ToString(2));
+        }
     }
 }

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -224,7 +224,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Nodes_Inline_Fragment_Issue_Comments()
         {
-            var expected = "query{nodes(ids:[\"123\"]){__typename ... on Issue{number items:comments{nodes{body}}}}}";
+            var expected = "query{nodes(ids:[\"123\"]){__typename ... on Issue{number items: comments{nodes{body}}}}}";
 
             var expression = new Query()
                 .Nodes(new[] { new ID("123") })

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -161,7 +161,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Repository_Licenses_Nested_Selects()
         {
-            var expected = "query{licenses{body conditions{description}}}";
+            var expected = "query{licenses{body items:conditions{description}}}";
 
             var expression = new Query()
                 .Licenses
@@ -206,7 +206,7 @@ namespace Octokit.GraphQL.Core.UnitTests
         [Fact]
         public void Nodes_Inline_Fragment_Issue_Comments()
         {
-            var expected = "query{nodes(ids:[\"123\"]){__typename ... on Issue{number comments{nodes{body}}}}}";
+            var expected = "query{nodes(ids:[\"123\"]){__typename ... on Issue{number items:comments{nodes{body}}}}}";
 
             var expression = new Query()
                 .Nodes(new[] { new ID("123") })

--- a/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/QueryBuilderTests.cs
@@ -173,6 +173,28 @@ namespace Octokit.GraphQL.Core.UnitTests
         }
 
         [Fact]
+        public void Repository_Licenses_Conditions_Select_ToDictionary()
+        {
+            var expected = "query{licenses{body items: conditions{key description}}}";
+
+            var expression = new Query()
+                .Licenses
+                .Select(x => new
+                {
+                    x.Body,
+                    Items = x.Conditions.Select(i => new
+                    {
+                        i.Key,
+                        i.Description,
+                    }).ToDictionary(d => d.Key, d => d.Description),
+                });
+
+            var query = expression.Compile();
+
+            Assert.Equal(expected, query.ToString(0));
+        }
+
+        [Fact]
         public void Repository_Issues_Nested_Select_With_Captured_Parameter()
         {
             var expected = @"query {

--- a/Octokit.GraphQL.Core.UnitTests/ResponseDeserializerTests.cs
+++ b/Octokit.GraphQL.Core.UnitTests/ResponseDeserializerTests.cs
@@ -201,7 +201,7 @@ namespace Octokit.GraphQL.Core.UnitTests
     ""data"":{
         ""licenses"": [{
             ""body"": ""foo"",
-            ""conditions"": [
+            ""items"": [
                 { ""description"": ""item1"" },
                 { ""description"": ""item2"" }
             ]
@@ -256,7 +256,7 @@ namespace Octokit.GraphQL.Core.UnitTests
     ""data"":{
         ""licenses"": [{
             ""body"": ""foo"",
-            ""conditions"": [
+            ""items"": [
                 { ""description"": ""item1"" },
                 { ""description"": ""item2"" }
             ]
@@ -292,7 +292,7 @@ namespace Octokit.GraphQL.Core.UnitTests
     ""data"":{
         ""licenses"": [{
             ""body"": ""foo"",
-            ""conditions"": [
+            ""items"": [
                 { ""key"": ""item1"", ""description"": ""foo"" },
                 { ""key"": ""item2"", ""description"": ""bar"" }
             ]
@@ -364,7 +364,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             var data = @"{
     ""data"":{
         ""repository"": {
-            ""issue"": {
+            ""value"": {
                 ""title"": ""foo"",
                 ""number"": ""42""
             }
@@ -398,7 +398,7 @@ namespace Octokit.GraphQL.Core.UnitTests
             var data = @"{
     ""data"":{
         ""repository"": {
-            ""issue"": {
+            ""value"": {
                 ""title"": ""foo"",
                 ""number"": ""42""
             }

--- a/Octokit.GraphQL.Core/Core/Builders/AliasedExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AliasedExpression.cs
@@ -4,17 +4,42 @@ using System.Reflection;
 
 namespace Octokit.GraphQL.Core.Builders
 {
+    /// <summary>
+    /// Marker to denote that an expression should be assigned an alias in the GraphQL query.
+    /// </summary>
     class AliasedExpression : Expression
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AliasedExpression"/> class.
+        /// </summary>
+        /// <param name="inner">The expression.</param>
+        /// <param name="alias">The alias.</param>
         public AliasedExpression(Expression inner, MemberInfo alias)
         {
             Inner = inner;
             Alias = alias;
         }
 
+        /// <summary>
+        /// Gets the expression that will be assigned an alias.
+        /// </summary>
         public Expression Inner { get; }
+
+        /// <summary>
+        /// Gets the alias.
+        /// </summary>
         public MemberInfo Alias { get; }
 
+        /// <summary>
+        /// Wraps an expression in a <see cref="AliasedExpression"/> if <paramref name="alias"/> is
+        /// not null.
+        /// </summary>
+        /// <param name="inner">The expression.</param>
+        /// <param name="alias">The alias.</param>
+        /// <returns>
+        /// An <see cref="AliasedExpression"/> if <paramref name="alias"/> is non-null; otherwise
+        /// <paramref name="inner"/>.
+        /// </returns>
         public static Expression WrapIfNeeded(Expression inner, MemberInfo alias)
         {
             return alias != null ? new AliasedExpression(inner, alias) : inner;

--- a/Octokit.GraphQL.Core/Core/Builders/AliasedExpression.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/AliasedExpression.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Octokit.GraphQL.Core.Builders
+{
+    class AliasedExpression : Expression
+    {
+        public AliasedExpression(Expression inner, MemberInfo alias)
+        {
+            Inner = inner;
+            Alias = alias;
+        }
+
+        public Expression Inner { get; }
+        public MemberInfo Alias { get; }
+
+        public static Expression WrapIfNeeded(Expression inner, MemberInfo alias)
+        {
+            return alias != null ? new AliasedExpression(inner, alias) : inner;
+        }
+    }
+}

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -374,7 +374,7 @@ namespace Octokit.GraphQL.Core.Builders
                 }
                 else
                 {
-                    var instance = Visit(expression);
+                    var instance = Visit(AliasedExpression.WrapIfNeeded(expression, alias));
 
                     if (isSubqueryPager)
                     {
@@ -390,7 +390,7 @@ namespace Octokit.GraphQL.Core.Builders
                         this.pageInfo = CreateSelectTokenExpression(selections);
                     }
 
-                    var field = syntax.AddField(node.Member, alias);
+                    var field = syntax.AddField(node.Member);
                     return instance.AddIndexer(field);
                 }
             }

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -610,7 +610,8 @@ namespace Octokit.GraphQL.Core.Builders
             }
             else if (expression.Method.GetGenericMethodDefinition() == QueryableListExtensions.ToDictionaryMethod)
             {
-                var instance = Visit(expression.Arguments[0]);
+                var source = expression.Arguments[0];
+                var instance = Visit(AliasedExpression.WrapIfNeeded(source, alias));
                 var keySelect = expression.Arguments[1].GetLambda();
                 var valueSelect = expression.Arguments[2].GetLambda();
                 var inputType = GetEnumerableItemType(instance.Type);

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -412,13 +412,9 @@ namespace Octokit.GraphQL.Core.Builders
             if (node.NodeType == ExpressionType.Convert)
             {
                 var rewritten = Visit(AliasedExpression.WrapIfNeeded(node.Operand, alias));
-
-                if (rewritten.Type == typeof(JToken))
-                {
-                    return Expression.Convert(
-                        rewritten.AddCast(node.Operand.Type),
-                        node.Type);
-                }
+                return Expression.Convert(
+                    rewritten.AddCast(node.Operand.Type),
+                    node.Type);
             }
 
             return node.Update(Visit(node.Operand));

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -396,7 +396,7 @@ namespace Octokit.GraphQL.Core.Builders
             }
             else
             {
-                var instance = Visit(node.Expression);
+                var instance = Visit(AliasedExpression.WrapIfNeeded(node.Expression, alias));
 
                 if (ExpressionWasRewritten(node.Expression, instance))
                 {

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -411,7 +411,7 @@ namespace Octokit.GraphQL.Core.Builders
         {
             if (node.NodeType == ExpressionType.Convert)
             {
-                var rewritten = Visit(node.Operand);
+                var rewritten = Visit(AliasedExpression.WrapIfNeeded(node.Operand, alias));
 
                 if (rewritten.Type == typeof(JToken))
                 {

--- a/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
+++ b/Octokit.GraphQL.Core/Core/Builders/QueryBuilder.cs
@@ -279,6 +279,10 @@ namespace Octokit.GraphQL.Core.Builders
                     {
                         rewritten = VisitMethodCall(call, alias);
                     }
+                    else if (arg is UnaryExpression unary)
+                    {
+                        rewritten = VisitUnary(unary, alias);
+                    }
                     else
                     {
                         rewritten = Visit(arg);
@@ -326,19 +330,7 @@ namespace Octokit.GraphQL.Core.Builders
 
         protected override Expression VisitUnary(UnaryExpression node)
         {
-            if (node.NodeType == ExpressionType.Convert)
-            {
-                var rewritten = Visit(node.Operand);
-
-                if (rewritten.Type == typeof(JToken))
-                {
-                    return Expression.Convert(
-                        rewritten.AddCast(node.Operand.Type),
-                        node.Type);
-                }
-            }
-
-            return node.Update(Visit(node.Operand));
+            return VisitUnary(node, null);
         }
 
         private void Initialize()
@@ -413,6 +405,23 @@ namespace Octokit.GraphQL.Core.Builders
 
                 return node.Update(instance);
             }
+        }
+
+        private Expression VisitUnary(UnaryExpression node, MemberInfo alias)
+        {
+            if (node.NodeType == ExpressionType.Convert)
+            {
+                var rewritten = Visit(node.Operand);
+
+                if (rewritten.Type == typeof(JToken))
+                {
+                    return Expression.Convert(
+                        rewritten.AddCast(node.Operand.Type),
+                        node.Type);
+                }
+            }
+
+            return node.Update(Visit(node.Operand));
         }
 
         private Expression<Func<JObject, IEnumerable<JToken>>> CreatePageInfoExpression()

--- a/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
+++ b/Octokit.GraphQL.UnitTests/QueryBuilderTests.cs
@@ -106,8 +106,10 @@ namespace Octokit.GraphQL.UnitTests
       }
     }
   }
-  viewer {
+  login: viewer {
     login
+  }
+  email: viewer {
     email
   }
 }";


### PR DESCRIPTION
- Fixing the follow bug:
    **Query**:
    ```
    var expression = new Query()
      .Select(q => new
      {
          repo1 = q.Repository("foo", "bar").Select(repository => new { repository.Name }).SingleOrDefault(),
          repo2 = q.Repository("foo", "bar").Select(repository => new { repository.Name }).SingleOrDefault()
      });
    ```
    **Expected**:
    ```
    query {
      repo1: repository(owner: ""foo"", name: ""bar"") {
        name
      }
      repo2: repository(owner: ""foo"", name: ""bar"") {
        name
      }
    }
    ```
    **Actual**:
    ```
    query {
      repository(owner: "foo", name: "bar", owner: "foo", name: "bar") {
        name
      }
    }
    ```